### PR TITLE
ci: fix github actions workflow permissions

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,7 +1,7 @@
 name: Protocol Liaison (XHedge Reviewer)
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
     inputs:
@@ -12,6 +12,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 jobs:
   review:


### PR DESCRIPTION
## Description
Fixes the failing Action `Protocol Liaison (XHedge Reviewer)` due to lacking execution privileges from forks.

### Changes Made
- Modified the trigger from `pull_request` to `pull_request_target`. Pull requests submitted from external forks receive a downgraded, read-only `GITHUB_TOKEN` dynamically which overrides explicitly stated `permissions:`. Using `pull_request_target` provisions the workflow environment on the base repository where explicit permissions can be correctly requested, fixing the blocking `GraphQL` and `Resource not accessible` errors when attempting `gh pr comment` or `gh pr merge`.
- Added the `issues: write` permission block context to fully support the CLI API layer `gh pr comment` interactions.

**Security Warning**: Since `pull_request_target` evaluates based on the base repo contexts, merging this PR enables code execution (from external forks: `cargo build` and `npm run build`) in a privileged state. Ensure branch protection remains strict or consider segregating builds.
