### PR TITLE
feat: add /settings page with notification and display preferences [F…

### DIFF
--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -1,0 +1,267 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTheme } from "next-themes";
+import { Settings, Bell, Palette, Monitor, Sun, Moon, Save, Check } from "lucide-react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { cn } from "@/lib/utils";
+import { useCurrency, Currency } from "@/app/context/CurrencyContext";
+
+const NOTIFICATIONS_KEY = "xhedge-notifications";
+
+interface NotificationPreferences {
+  vaultAlerts: boolean;
+  priceAlerts: boolean;
+  transactionAlerts: boolean;
+  weeklyReports: boolean;
+}
+
+const DEFAULT_NOTIFICATIONS: NotificationPreferences = {
+  vaultAlerts: true,
+  priceAlerts: true,
+  transactionAlerts: true,
+  weeklyReports: false,
+};
+
+const THEME_OPTIONS = [
+  { value: "light", label: "Light", icon: Sun },
+  { value: "dark", label: "Dark", icon: Moon },
+  { value: "system", label: "System", icon: Monitor },
+] as const;
+
+const CURRENCY_OPTIONS = [
+  { value: Currency.USD, label: "US Dollar", symbol: "$", description: "United States Dollar" },
+  { value: Currency.NGN, label: "Nigerian Naira", symbol: "₦", description: "Nigerian Naira" },
+] as const;
+
+export default function SettingsPage() {
+  const { theme, setTheme } = useTheme();
+  const { currency, setCurrency } = useCurrency();
+  const [notifications, setNotifications] = useState<NotificationPreferences>(DEFAULT_NOTIFICATIONS);
+  const [saved, setSaved] = useState(false);
+  const [mounted, setMounted] = useState(false);
+
+  // Avoid hydration mismatch for theme
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  // Load notification preferences from localStorage
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(NOTIFICATIONS_KEY);
+      if (stored) {
+        const parsed = JSON.parse(stored) as Partial<NotificationPreferences>;
+        setNotifications((prev) => ({ ...prev, ...parsed }));
+      }
+    } catch {
+      // use defaults if parsing fails
+    }
+  }, []);
+
+  const handleNotificationChange = (key: keyof NotificationPreferences, value: boolean) => {
+    setNotifications((prev) => {
+      const updated = { ...prev, [key]: value };
+      try {
+        localStorage.setItem(NOTIFICATIONS_KEY, JSON.stringify(updated));
+      } catch {
+        // storage may be unavailable in some environments
+      }
+      return updated;
+    });
+  };
+
+  const handleSave = () => {
+    try {
+      localStorage.setItem(NOTIFICATIONS_KEY, JSON.stringify(notifications));
+    } catch {
+      // storage may be unavailable in some environments
+    }
+    setSaved(true);
+    setTimeout(() => setSaved(false), 2000);
+  };
+
+  return (
+    <div className="min-h-screen p-8">
+      <div className="mx-auto max-w-3xl space-y-8">
+        {/* Page Header */}
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+            <Settings className="h-5 w-5 text-primary" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold text-foreground">Settings</h1>
+            <p className="text-sm text-muted-foreground">
+              Manage your notification and display preferences
+            </p>
+          </div>
+        </div>
+
+        {/* Display Preferences */}
+        <Card>
+          <CardHeader>
+            <div className="flex items-center gap-2">
+              <Palette className="h-4 w-4 text-primary" />
+              <CardTitle className="text-lg">Display Preferences</CardTitle>
+            </div>
+            <CardDescription>
+              Customize how XHedge looks and formats data for you.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            {/* Theme Selection */}
+            <div className="space-y-3">
+              <Label className="text-sm font-medium text-foreground">Theme</Label>
+              <div className="grid grid-cols-3 gap-3">
+                {THEME_OPTIONS.map(({ value, label, icon: Icon }) => (
+                  <button
+                    key={value}
+                    onClick={() => setTheme(value)}
+                    className={cn(
+                      "flex flex-col items-center gap-2 rounded-lg border p-4 text-sm font-medium transition-all",
+                      mounted && theme === value
+                        ? "border-primary bg-primary/10 text-primary"
+                        : "border-border bg-card text-muted-foreground hover:border-primary/50 hover:bg-accent hover:text-foreground"
+                    )}
+                  >
+                    <Icon className="h-5 w-5" />
+                    {label}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Currency Format */}
+            <div className="space-y-3">
+              <Label className="text-sm font-medium text-foreground">Currency Format</Label>
+              <div className="grid grid-cols-2 gap-3">
+                {CURRENCY_OPTIONS.map(({ value, label, symbol, description }) => (
+                  <button
+                    key={value}
+                    onClick={() => setCurrency(value)}
+                    className={cn(
+                      "flex items-center gap-3 rounded-lg border p-4 text-left transition-all",
+                      currency === value
+                        ? "border-primary bg-primary/10"
+                        : "border-border bg-card hover:border-primary/50 hover:bg-accent"
+                    )}
+                  >
+                    <span
+                      className={cn(
+                        "flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-base font-bold",
+                        currency === value
+                          ? "bg-primary text-primary-foreground"
+                          : "bg-muted text-muted-foreground"
+                      )}
+                    >
+                      {symbol}
+                    </span>
+                    <div>
+                      <p
+                        className={cn(
+                          "text-sm font-medium",
+                          currency === value ? "text-primary" : "text-foreground"
+                        )}
+                      >
+                        {label}
+                      </p>
+                      <p className="text-xs text-muted-foreground">{description}</p>
+                    </div>
+                  </button>
+                ))}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Notification Preferences */}
+        <Card>
+          <CardHeader>
+            <div className="flex items-center gap-2">
+              <Bell className="h-4 w-4 text-primary" />
+              <CardTitle className="text-lg">Notification Preferences</CardTitle>
+            </div>
+            <CardDescription>
+              Control which alerts and updates you receive.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-1">
+            <NotificationRow
+              label="Vault Alerts"
+              description="Get notified about vault deposit and withdrawal activity."
+              checked={notifications.vaultAlerts}
+              onCheckedChange={(val) => handleNotificationChange("vaultAlerts", val)}
+            />
+            <Divider />
+            <NotificationRow
+              label="Price Alerts"
+              description="Receive alerts when asset prices reach significant thresholds."
+              checked={notifications.priceAlerts}
+              onCheckedChange={(val) => handleNotificationChange("priceAlerts", val)}
+            />
+            <Divider />
+            <NotificationRow
+              label="Transaction Alerts"
+              description="Be notified when your transactions are confirmed on-chain."
+              checked={notifications.transactionAlerts}
+              onCheckedChange={(val) => handleNotificationChange("transactionAlerts", val)}
+            />
+            <Divider />
+            <NotificationRow
+              label="Weekly Reports"
+              description="Receive a weekly summary of your portfolio performance."
+              checked={notifications.weeklyReports}
+              onCheckedChange={(val) => handleNotificationChange("weeklyReports", val)}
+            />
+          </CardContent>
+        </Card>
+
+        {/* Save Button */}
+        <div className="flex justify-end">
+          <Button onClick={handleSave} className="gap-2 px-6">
+            {saved ? (
+              <>
+                <Check className="h-4 w-4" />
+                Saved
+              </>
+            ) : (
+              <>
+                <Save className="h-4 w-4" />
+                Save Preferences
+              </>
+            )}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function NotificationRow({
+  label,
+  description,
+  checked,
+  onCheckedChange,
+}: {
+  label: string;
+  description: string;
+  checked: boolean;
+  onCheckedChange: (val: boolean) => void;
+}) {
+  return (
+    <div className="flex items-center justify-between py-4">
+      <div className="space-y-0.5">
+        <Label className="text-sm font-medium text-foreground">{label}</Label>
+        <p className="text-xs text-muted-foreground">{description}</p>
+      </div>
+      <Switch checked={checked} onCheckedChange={onCheckedChange} />
+    </div>
+  );
+}
+
+function Divider() {
+  return <div className="h-px bg-border" />;
+}

--- a/frontend/components/ui/switch.tsx
+++ b/frontend/components/ui/switch.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+interface SwitchProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  checked: boolean
+  onCheckedChange: (checked: boolean) => void
+}
+
+const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(
+  ({ className, checked, onCheckedChange, disabled, ...props }, ref) => (
+    <button
+      ref={ref}
+      role="switch"
+      aria-checked={checked}
+      disabled={disabled}
+      onClick={() => onCheckedChange(!checked)}
+      className={cn(
+        "relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50",
+        checked ? "bg-primary" : "bg-input",
+        className
+      )}
+      {...props}
+    >
+      <span
+        className={cn(
+          "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform",
+          checked ? "translate-x-5" : "translate-x-0"
+        )}
+      />
+    </button>
+  )
+)
+Switch.displayName = "Switch"
+
+export { Switch }


### PR DESCRIPTION
…E-16]

- Add app/settings/page.tsx with dedicated user settings route
- Implement notification preferences (vault, price, transaction alerts, weekly reports)
- Implement display preferences (theme: light/dark/system, currency: USD/NGN)
- Persist notification preferences to localStorage (key: xhedge-notifications)
- Currency preference already persisted via CurrencyContext (key: xh_currency)
- Theme preference persisted by next-themes ThemeProvider
- Add reusable Switch UI component (components/ui/switch.tsx)
- Settings accessible from existing sidebar navigation link

Closes #208