### PR TITLE
feat(sc): implement oracle allocation validation and zero-address guard

### DIFF
--- a/docs/ISSUES-SMARTCONTRACT.md
+++ b/docs/ISSUES-SMARTCONTRACT.md
@@ -280,15 +280,15 @@ This document tracks the detailed development tasks for the Soroban smart contra
   - [ ] Reject rebalance if oracle data is older than `MAX_STALENESS` (configurable).
   - [ ] Emit `StaleOracleRejected` event.
 
-### Issue #SC-24b: Oracle Data Validation — Allocation Sanity Checks
+### Issue #SC-24b: Oracle Data Validation — Allocation Sanity Checks [COMPLETED]
 **Priority:** High
 **Labels:** `smart-contract`, `security`, `oracle`
 **Description:** Validate the oracle's allocation data for logical correctness before rebalancing.
 - **Tasks:**
-  - [ ] Validate allocation percentages sum to 100% in `rebalance()`.
-  - [ ] Validate individual allocation values are non-negative.
-  - [ ] Reject allocations with zero-address strategies.
-  - [ ] Write tests for malformed allocation scenarios.
+  - [x] Validate allocation percentages sum to 100% in `rebalance()`.
+  - [x] Validate individual allocation values are non-negative.
+  - [x] Reject allocations with zero-address strategies.
+  - [x] Write tests for malformed allocation scenarios.
 
 ### Issue #SC-25a: Withdrawal Queue — Core Queue Mechanism
 **Priority:** Medium

--- a/smartcontract/contracts/volatility_shield/src/lib.rs
+++ b/smartcontract/contracts/volatility_shield/src/lib.rs
@@ -159,14 +159,20 @@ impl VolatilityShield {
     // ── Governance ────────────────────────────
     pub fn propose_action(env: Env, proposer: Address, action: ActionType) -> u64 {
         proposer.require_auth();
-        
+
         let guardians: Vec<Address> = env.storage().instance().get(&DataKey::Guardians).unwrap();
         if !guardians.contains(proposer.clone()) {
             panic!("not a guardian");
         }
 
-        let id = env.storage().instance().get(&DataKey::NextProposalId).unwrap_or(1);
-        env.storage().instance().set(&DataKey::NextProposalId, &(id + 1));
+        let id = env
+            .storage()
+            .instance()
+            .get(&DataKey::NextProposalId)
+            .unwrap_or(1);
+        env.storage()
+            .instance()
+            .set(&DataKey::NextProposalId, &(id + 1));
 
         let proposed_at = env.ledger().timestamp();
         let mut proposal = Proposal {
@@ -179,12 +185,14 @@ impl VolatilityShield {
         };
 
         // Emit TimelockStarted event
-        env.events().publish(
-            (symbol_short!("Timelock"),),
-            (id, proposed_at),
-        );
+        env.events()
+            .publish((symbol_short!("Timelock"),), (id, proposed_at));
 
-        let threshold: u32 = env.storage().instance().get(&DataKey::Threshold).unwrap_or(1);
+        let threshold: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::Threshold)
+            .unwrap_or(1);
         if threshold <= 1 {
             // Try to execute, but if timelock hasn't elapsed, the proposal will remain unexecuted
             let res = Self::execute_action(&env, &action, proposed_at);
@@ -197,9 +205,15 @@ impl VolatilityShield {
             }
         }
 
-        let mut proposals: Map<u64, Proposal> = env.storage().instance().get(&DataKey::Proposals).unwrap_or(Map::new(&env));
+        let mut proposals: Map<u64, Proposal> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Proposals)
+            .unwrap_or(Map::new(&env));
         proposals.set(id, proposal);
-        env.storage().instance().set(&DataKey::Proposals, &proposals);
+        env.storage()
+            .instance()
+            .set(&DataKey::Proposals, &proposals);
 
         id
     }
@@ -207,12 +221,20 @@ impl VolatilityShield {
     pub fn approve_action(env: Env, guardian: Address, proposal_id: u64) -> Result<(), Error> {
         guardian.require_auth();
 
-        let guardians: Vec<Address> = env.storage().instance().get(&DataKey::Guardians).ok_or(Error::NotInitialized)?;
+        let guardians: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Guardians)
+            .ok_or(Error::NotInitialized)?;
         if !guardians.contains(guardian.clone()) {
             return Err(Error::Unauthorized);
         }
 
-        let mut proposals: Map<u64, Proposal> = env.storage().instance().get(&DataKey::Proposals).ok_or(Error::NotInitialized)?;
+        let mut proposals: Map<u64, Proposal> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Proposals)
+            .ok_or(Error::NotInitialized)?;
         let mut proposal = proposals.get(proposal_id).ok_or(Error::ProposalNotFound)?;
 
         if proposal.executed {
@@ -224,49 +246,74 @@ impl VolatilityShield {
         }
 
         proposal.approvals.push_back(guardian);
-        
-        let threshold: u32 = env.storage().instance().get(&DataKey::Threshold).unwrap_or(1);
+
+        let threshold: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::Threshold)
+            .unwrap_or(1);
         if proposal.approvals.len() >= threshold {
             Self::execute_action(&env, &proposal.action, proposal.proposed_at)?;
             proposal.executed = true;
         }
 
         proposals.set(proposal_id, proposal);
-        env.storage().instance().set(&DataKey::Proposals, &proposals);
+        env.storage()
+            .instance()
+            .set(&DataKey::Proposals, &proposals);
 
         Ok(())
     }
 
     pub fn add_guardian(env: Env, guardian: Address) -> Result<(), Error> {
         Self::require_admin(&env);
-        let mut guardians: Vec<Address> = env.storage().instance().get(&DataKey::Guardians).unwrap_or(Vec::new(&env));
+        let mut guardians: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Guardians)
+            .unwrap_or(Vec::new(&env));
         if guardians.contains(guardian.clone()) {
             return Ok(());
         }
         guardians.push_back(guardian);
-        env.storage().instance().set(&DataKey::Guardians, &guardians);
+        env.storage()
+            .instance()
+            .set(&DataKey::Guardians, &guardians);
         Ok(())
     }
 
     pub fn remove_guardian(env: Env, guardian: Address) -> Result<(), Error> {
         Self::require_admin(&env);
-        let mut guardians: Vec<Address> = env.storage().instance().get(&DataKey::Guardians).unwrap_or(Vec::new(&env));
-        let index = guardians.first_index_of(guardian).ok_or(Error::Unauthorized)?;
+        let mut guardians: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Guardians)
+            .unwrap_or(Vec::new(&env));
+        let index = guardians
+            .first_index_of(guardian)
+            .ok_or(Error::Unauthorized)?;
         guardians.remove(index);
-        env.storage().instance().set(&DataKey::Guardians, &guardians);
+        env.storage()
+            .instance()
+            .set(&DataKey::Guardians, &guardians);
         Ok(())
     }
 
     pub fn set_threshold(env: Env, threshold: u32) -> Result<(), Error> {
         Self::require_admin(&env);
-        let guardians: Vec<Address> = env.storage().instance().get(&DataKey::Guardians).unwrap_or(Vec::new(&env));
+        let guardians: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Guardians)
+            .unwrap_or(Vec::new(&env));
         if threshold == 0 || threshold > guardians.len() {
             return Err(Error::Unauthorized);
         }
-        env.storage().instance().set(&DataKey::Threshold, &threshold);
+        env.storage()
+            .instance()
+            .set(&DataKey::Threshold, &threshold);
         Ok(())
     }
-
 
     fn execute_action(env: &Env, action: &ActionType, proposed_at: u64) -> Result<(), Error> {
         // Check if timelock has elapsed
@@ -285,17 +332,18 @@ impl VolatilityShield {
         }
 
         // Emit TimelockExecuted event
-        env.events().publish(
-            (symbol_short!("TlockExec"),),
-            (),
-        );
+        env.events().publish((symbol_short!("TlockExec"),), ());
 
         Ok(())
     }
 
     fn assert_timelock_elapsed(env: &Env, proposed_at: u64) -> Result<(), Error> {
-        let timelock_duration: u64 = env.storage().instance().get(&DataKey::TimelockDuration).unwrap_or(0);
-        
+        let timelock_duration: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::TimelockDuration)
+            .unwrap_or(0);
+
         // If timelock duration is 0, no timelock is enforced
         if timelock_duration == 0 {
             return Ok(());
@@ -303,7 +351,7 @@ impl VolatilityShield {
 
         let now = env.ledger().timestamp();
         let elapsed = now.checked_sub(proposed_at).unwrap_or(0);
-        
+
         if elapsed < timelock_duration {
             return Err(Error::TimelockNotElapsed);
         }
@@ -346,14 +394,22 @@ impl VolatilityShield {
             .set(&DataKey::MaxStaleness, &3600u64);
 
         // Initialize contract version
-        env.storage().instance().set(&DataKey::ContractVersion, &1u32);
+        env.storage()
+            .instance()
+            .set(&DataKey::ContractVersion, &1u32);
 
         // Multisig initialization
-        env.storage().instance().set(&DataKey::Guardians, &guardians);
-        env.storage().instance().set(&DataKey::Threshold, &threshold);
+        env.storage()
+            .instance()
+            .set(&DataKey::Guardians, &guardians);
+        env.storage()
+            .instance()
+            .set(&DataKey::Threshold, &threshold);
 
         // Initialize contract version
-        env.storage().instance().set(&DataKey::ContractVersion, &1u32);
+        env.storage()
+            .instance()
+            .set(&DataKey::ContractVersion, &1u32);
 
         Ok(())
     }
@@ -457,7 +513,11 @@ impl VolatilityShield {
         // --------------------------------
 
         // Check if withdrawal exceeds queue threshold
-        let queue_threshold: i128 = env.storage().instance().get(&DataKey::WithdrawQueueThreshold).unwrap_or(i128::MAX);
+        let queue_threshold: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::WithdrawQueueThreshold)
+            .unwrap_or(i128::MAX);
         if assets_to_withdraw > queue_threshold {
             // Queue the withdrawal instead of processing immediately
             Self::queue_withdraw(env, from, shares);
@@ -492,7 +552,6 @@ impl VolatilityShield {
             .publish((symbol_short!("withdraw"), from.clone()), shares);
     }
 
-
     // ── Withdrawal Queue ───────────────────────
     /// Queue a withdrawal request for processing later.
     /// This is called automatically by withdraw() when the amount exceeds the threshold.
@@ -511,12 +570,14 @@ impl VolatilityShield {
         }
 
         let assets_to_withdraw = Self::convert_to_assets(env.clone(), shares);
-        
+
         // Check if withdrawal exceeds queue threshold
-        let queue_threshold: i128 = env.storage().instance()
+        let queue_threshold: i128 = env
+            .storage()
+            .instance()
             .get(&DataKey::WithdrawQueueThreshold)
             .unwrap_or(i128::MAX);
-        
+
         if assets_to_withdraw <= queue_threshold {
             panic!("withdrawal amount does not exceed queue threshold");
         }
@@ -529,12 +590,16 @@ impl VolatilityShield {
         };
 
         // Add to pending withdrawals queue
-        let mut pending_withdrawals: Vec<QueuedWithdrawal> = env.storage().instance()
+        let mut pending_withdrawals: Vec<QueuedWithdrawal> = env
+            .storage()
+            .instance()
             .get(&DataKey::PendingWithdrawals)
             .unwrap_or(Vec::new(&env));
-        
+
         pending_withdrawals.push_back(queued_withdrawal);
-        env.storage().instance().set(&DataKey::PendingWithdrawals, &pending_withdrawals);
+        env.storage()
+            .instance()
+            .set(&DataKey::PendingWithdrawals, &pending_withdrawals);
 
         // Emit WithdrawQueued event
         env.events()
@@ -548,25 +613,34 @@ impl VolatilityShield {
         if threshold < 0 {
             panic!("threshold must be non-negative");
         }
-        env.storage().instance().set(&DataKey::WithdrawQueueThreshold, &threshold);
-        env.events().publish((symbol_short!("QueueThr"),), threshold);
+        env.storage()
+            .instance()
+            .set(&DataKey::WithdrawQueueThreshold, &threshold);
+        env.events()
+            .publish((symbol_short!("QueueThr"),), threshold);
     }
 
     /// Process queued withdrawals (admin only)
     pub fn process_queued_withdrawals(env: Env, limit: u32) -> u32 {
         Self::require_admin(&env);
-        
-        let pending_withdrawals: Vec<QueuedWithdrawal> = env.storage().instance()
+
+        let pending_withdrawals: Vec<QueuedWithdrawal> = env
+            .storage()
+            .instance()
             .get(&DataKey::PendingWithdrawals)
             .unwrap_or(Vec::new(&env));
-        
+
         let mut processed = 0;
         let mut remaining_withdrawals = Vec::new(&env);
-        
+
         let mut total_shares = Self::total_shares(&env);
         let mut total_assets = Self::total_assets(&env);
 
-        let token: Address = env.storage().instance().get(&DataKey::Token).expect("Token not initialized");
+        let token: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Token)
+            .expect("Token not initialized");
         let token_client = token::Client::new(&env, &token);
 
         for queued_withdrawal in pending_withdrawals.iter() {
@@ -574,46 +648,52 @@ impl VolatilityShield {
                 remaining_withdrawals.push_back(queued_withdrawal.clone());
                 continue;
             }
-            
+
             // Process the withdrawal
             let assets_to_withdraw = Self::convert_to_assets(env.clone(), queued_withdrawal.shares);
-            
+
             total_shares = total_shares.checked_sub(queued_withdrawal.shares).unwrap();
             total_assets = total_assets.checked_sub(assets_to_withdraw).unwrap();
-            
+
             token_client.transfer(
                 &env.current_contract_address(),
                 &queued_withdrawal.user,
                 &assets_to_withdraw,
             );
-            
-            env.events()
-                .publish((symbol_short!("WithdrawP"), queued_withdrawal.user.clone()), queued_withdrawal.shares);
-            
+
+            env.events().publish(
+                (symbol_short!("WithdrawP"), queued_withdrawal.user.clone()),
+                queued_withdrawal.shares,
+            );
+
             processed += 1;
         }
-        
+
         // Update totals
         Self::set_total_shares(env.clone(), total_shares);
         Self::set_total_assets(env.clone(), total_assets);
-        
+
         // Update remaining withdrawals
-        env.storage().instance().set(&DataKey::PendingWithdrawals, &remaining_withdrawals);
-        
+        env.storage()
+            .instance()
+            .set(&DataKey::PendingWithdrawals, &remaining_withdrawals);
+
         processed
     }
 
     /// Cancel a queued withdrawal
     pub fn cancel_queued_withdrawal(env: Env, from: Address) -> Result<(), Error> {
         from.require_auth();
-        
-        let mut pending_withdrawals: Vec<QueuedWithdrawal> = env.storage().instance()
+
+        let mut pending_withdrawals: Vec<QueuedWithdrawal> = env
+            .storage()
+            .instance()
             .get(&DataKey::PendingWithdrawals)
             .unwrap_or(Vec::new(&env));
-        
+
         let mut found_index: Option<u32> = None;
         let mut found_withdrawal: Option<QueuedWithdrawal> = None;
-        
+
         for i in 0..pending_withdrawals.len() {
             let w = pending_withdrawals.get(i).unwrap();
             if w.user == from {
@@ -622,37 +702,41 @@ impl VolatilityShield {
                 break;
             }
         }
-        
+
         let index = found_index.ok_or(Error::WithdrawalNotFound)?;
         let w = found_withdrawal.unwrap();
-        
+
         pending_withdrawals.remove(index);
-        
+
         // Return shares to user balance
         let balance_key = DataKey::Balance(from.clone());
         let current_balance: i128 = env.storage().persistent().get(&balance_key).unwrap_or(0);
-        env.storage().persistent().set(&balance_key, &(current_balance + w.shares));
-        
-        env.storage().instance().set(&DataKey::PendingWithdrawals, &pending_withdrawals);
-        
-        env.events().publish(
-            (symbol_short!("WdrwCncl"),),
-            (from, w.shares),
-        );
-        
+        env.storage()
+            .persistent()
+            .set(&balance_key, &(current_balance + w.shares));
+
+        env.storage()
+            .instance()
+            .set(&DataKey::PendingWithdrawals, &pending_withdrawals);
+
+        env.events()
+            .publish((symbol_short!("WdrwCncl"),), (from, w.shares));
+
         Ok(())
     }
 
     /// Get the current withdrawal queue threshold
     pub fn get_withdraw_queue_threshold(env: Env) -> i128 {
-        env.storage().instance()
+        env.storage()
+            .instance()
             .get(&DataKey::WithdrawQueueThreshold)
             .unwrap_or(i128::MAX)
     }
 
     /// Get all pending queued withdrawals
     pub fn get_pending_withdrawals(env: Env) -> Vec<QueuedWithdrawal> {
-        env.storage().instance()
+        env.storage()
+            .instance()
             .get(&DataKey::PendingWithdrawals)
             .unwrap_or(Vec::new(&env))
     }
@@ -667,7 +751,7 @@ impl VolatilityShield {
     /// **Access control**: must be called via the multi-sig governance system.
     fn internal_rebalance(env: &Env, max_slippage_bps: u32) -> Result<(), Error> {
         Self::check_version(env, 1);
-        let admin  = Self::read_admin(env);
+        let admin = Self::read_admin(env);
         let oracle = Self::get_oracle(env);
 
         // OR-auth: require that either Admin or Oracle authorised this invocation.
@@ -802,26 +886,43 @@ impl VolatilityShield {
     }
 
     /// Validates allocation data for logical correctness.
-    /// - Checks that all allocation percentages sum to 100% (10000 basis points)
-    /// - Ensures individual allocations are non-negative
-    /// - Rejects allocations with zero-address strategies
-    fn validate_allocations(_env: &Env, allocations: &Map<Address, i128>) -> Result<(), Error> {
-        let mut total_percentage: i128 = 0;
+    ///
+    /// Invariants enforced (all in a single O(n) pass over the allocation map):
+    /// - Every strategy address must be present in the on-chain strategy registry
+    ///   (`ZeroAddressStrategy`). This is the Soroban-native analogue of the EVM
+    ///   "zero-address" guard — an unregistered contract must never receive funds.
+    /// - Every individual allocation value must be non-negative (`NegativeAllocation`).
+    /// - Non-empty allocations must sum exactly to 10 000 basis points / 100%
+    ///   (`InvalidAllocationSum`). An empty map (total = 0) is accepted for
+    ///   initialization / reset purposes.
+    ///
+    /// Time complexity : O(n) where n = number of entries in the allocation map.
+    /// Space complexity: O(s) for the single registered-strategies Vec read from
+    ///                   storage, where s = number of registered strategies.
+    fn validate_allocations(env: &Env, allocations: &Map<Address, i128>) -> Result<(), Error> {
+        // Read the registered strategy registry once — O(s) space, one storage hit.
+        let registered: Vec<Address> = Self::get_strategies(env);
 
-        for (_strategy_addr, allocation) in allocations.iter() {
+        let mut total_bps: i128 = 0;
 
-            // Check for negative allocation
+        for (strategy_addr, allocation) in allocations.iter() {
+            // Guard 1: strategy must be in the on-chain registry.
+            if !registered.contains(strategy_addr.clone()) {
+                return Err(Error::ZeroAddressStrategy);
+            }
+
+            // Guard 2: individual allocation must be non-negative.
             if allocation < 0 {
                 return Err(Error::NegativeAllocation);
             }
 
-            // Sum up percentages
-            total_percentage = total_percentage.checked_add(allocation).unwrap_or(i128::MAX);
+            // Accumulate; saturate at i128::MAX on overflow (caught by sum check below).
+            total_bps = total_bps.checked_add(allocation).unwrap_or(i128::MAX);
         }
 
-        // Validate sum equals 100% (10000 basis points)
-        // Allow empty allocations (total = 0) for initialization
-        if total_percentage != 0 && total_percentage != 10000 {
+        // Guard 3: non-empty allocations must sum exactly to 100% (10 000 bps).
+        // An empty map (total_bps == 0) is allowed for initialization / reset.
+        if total_bps != 0 && total_bps != 10_000 {
             return Err(Error::InvalidAllocationSum);
         }
 
@@ -893,7 +994,7 @@ impl VolatilityShield {
     /// Check health of all strategies and compare expected vs actual balances
     pub fn check_strategy_health(env: Env) -> Result<Vec<Address>, Error> {
         Self::require_admin(&env);
-        
+
         let strategies = Self::get_strategies(&env);
         if strategies.is_empty() {
             return Err(Error::NoStrategies);
@@ -901,9 +1002,10 @@ impl VolatilityShield {
 
         let mut unhealthy_strategies = Vec::new(&env);
         let current_time = env.ledger().timestamp();
-        
+
         // Get expected allocations from oracle data
-        let expected_allocations: Map<Address, i128> = env.storage()
+        let expected_allocations: Map<Address, i128> = env
+            .storage()
             .instance()
             .get(&DataKey::TargetAllocations)
             .unwrap_or(Map::new(&env));
@@ -911,23 +1013,22 @@ impl VolatilityShield {
         for strategy_addr in strategies.iter() {
             let strategy = StrategyClient::new(&env, strategy_addr.clone());
             let actual_balance = strategy.balance();
-            
+
             // Get expected balance from allocations
-            let expected_balance = expected_allocations
-                .get(strategy_addr.clone())
-                .unwrap_or(0);
-            
+            let expected_balance = expected_allocations.get(strategy_addr.clone()).unwrap_or(0);
+
             // Get current health data
             let health_key = DataKey::StrategyHealth(strategy_addr.clone());
-            let current_health = env.storage()
-                .instance()
-                .get(&health_key)
-                .unwrap_or(StrategyHealth {
-                    last_known_balance: expected_balance,
-                    last_check_timestamp: current_time,
-                    is_healthy: true,
-                });
-            
+            let current_health =
+                env.storage()
+                    .instance()
+                    .get(&health_key)
+                    .unwrap_or(StrategyHealth {
+                        last_known_balance: expected_balance,
+                        last_check_timestamp: current_time,
+                        is_healthy: true,
+                    });
+
             // Check if strategy is unhealthy (significant deviation from expected)
             let balance_deviation = if expected_balance > 0 {
                 // Allow 10% deviation before flagging as unhealthy
@@ -937,12 +1038,13 @@ impl VolatilityShield {
                 // If expected is 0, any positive actual balance is considered healthy
                 false
             };
-            
+
             let is_healthy = !balance_deviation;
-            
+
             // Update health data if changed
-            if is_healthy != current_health.is_healthy || 
-               actual_balance != current_health.last_known_balance {
+            if is_healthy != current_health.is_healthy
+                || actual_balance != current_health.last_known_balance
+            {
                 let new_health = StrategyHealth {
                     last_known_balance: actual_balance,
                     last_check_timestamp: current_time,
@@ -950,70 +1052,74 @@ impl VolatilityShield {
                 };
                 env.storage().instance().set(&health_key, &new_health);
             }
-            
+
             // If unhealthy, add to list for flagging
             if !is_healthy {
                 unhealthy_strategies.push_back(strategy_addr.clone());
             }
         }
-        
+
         Ok(unhealthy_strategies)
     }
 
     /// Flag a strategy as unhealthy (admin only)
     pub fn flag_strategy(env: Env, strategy: Address) -> Result<(), Error> {
         Self::require_admin(&env);
-        
+
         // Verify strategy exists
         let strategies = Self::get_strategies(&env);
         if !strategies.contains(strategy.clone()) {
             return Err(Error::NotInitialized);
         }
-        
+
         let health_key = DataKey::StrategyHealth(strategy.clone());
         let current_time = env.ledger().timestamp();
-        
+
         // Update health to unhealthy
         let updated_health = StrategyHealth {
             last_known_balance: 0, // Will be updated on next health check
             last_check_timestamp: current_time,
             is_healthy: false,
         };
-        
+
         env.storage().instance().set(&health_key, &updated_health);
-        
+
         // Emit StrategyFlagged event
         env.events()
             .publish((symbol_short!("StrategyF"), strategy.clone()), current_time);
-        
+
         Ok(())
     }
 
     /// Remove a strategy and withdraw all funds first (admin only)
     pub fn remove_strategy(env: Env, strategy: Address) -> Result<(), Error> {
         Self::require_admin(&env);
-        
+
         // Verify strategy exists
         let mut strategies = Self::get_strategies(&env);
         let strategy_index = strategies.iter().position(|s| s == strategy);
-        
+
         if strategy_index.is_none() {
             return Err(Error::NotInitialized);
         }
-        
+
         // Withdraw all funds from strategy first
         let strategy_client = StrategyClient::new(&env, strategy.clone());
         let strategy_balance = strategy_client.balance();
-        
+
         if strategy_balance > 0 {
             // Transfer all funds back to vault
             let asset_addr = Self::get_asset(&env);
             let token_client = token::Client::new(&env, &asset_addr);
-            
+
             // Withdraw from strategy
             strategy_client.withdraw(strategy_balance);
-            token_client.transfer(&strategy, &env.current_contract_address(), &strategy_balance);
-            
+            token_client.transfer(
+                &strategy,
+                &env.current_contract_address(),
+                &strategy_balance,
+            );
+
             // Update total assets to reflect returned funds
             let current_assets = Self::total_assets(&env);
             Self::set_total_assets(
@@ -1021,19 +1127,23 @@ impl VolatilityShield {
                 current_assets.checked_add(strategy_balance).unwrap(),
             );
         }
-        
+
         // Remove from strategies list
         strategies.remove(strategy_index.unwrap() as u32);
-        env.storage().instance().set(&DataKey::Strategies, &strategies);
-        
+        env.storage()
+            .instance()
+            .set(&DataKey::Strategies, &strategies);
+
         // Clean up health data
         let health_key = DataKey::StrategyHealth(strategy.clone());
         env.storage().instance().remove(&health_key);
-        
+
         // Emit StrategyRemoved event
-        env.events()
-            .publish((symbol_short!("StrategyR"), strategy.clone()), strategy_balance);
-        
+        env.events().publish(
+            (symbol_short!("StrategyR"), strategy.clone()),
+            strategy_balance,
+        );
+
         Ok(())
     }
 
@@ -1121,7 +1231,10 @@ impl VolatilityShield {
     }
 
     pub fn get_threshold(env: Env) -> u32 {
-        env.storage().instance().get(&DataKey::Threshold).unwrap_or(1)
+        env.storage()
+            .instance()
+            .get(&DataKey::Threshold)
+            .unwrap_or(1)
     }
 
     // ── Internal Helpers ──────────────────────
@@ -1226,7 +1339,6 @@ impl VolatilityShield {
             .publish((symbol_short!("Caps"), symbol_short!("withdraw")), per_tx);
     }
 
-
     pub fn set_max_staleness(env: Env, seconds: u64) {
         Self::require_admin(&env);
         env.storage()
@@ -1236,8 +1348,11 @@ impl VolatilityShield {
 
     pub fn set_timelock_duration(env: Env, duration: u64) {
         Self::require_admin(&env);
-        env.storage().instance().set(&DataKey::TimelockDuration, &duration);
-        env.events().publish((symbol_short!("TimelockD"),), duration);
+        env.storage()
+            .instance()
+            .set(&DataKey::TimelockDuration, &duration);
+        env.events()
+            .publish((symbol_short!("TimelockD"),), duration);
     }
 
     pub fn max_staleness(env: &Env) -> u64 {
@@ -1251,7 +1366,8 @@ impl VolatilityShield {
     pub fn upgrade(env: Env, new_wasm_hash: soroban_sdk::BytesN<32>) {
         Self::require_admin(&env);
         env.deployer().update_current_contract_wasm(new_wasm_hash);
-        env.events().publish((symbol_short!("upgrade"), symbol_short!("wasm")), ());
+        env.events()
+            .publish((symbol_short!("upgrade"), symbol_short!("wasm")), ());
     }
 
     pub fn migrate(env: Env, new_version: u32) {
@@ -1260,25 +1376,35 @@ impl VolatilityShield {
         if new_version <= current_version {
             panic!("new version must be greater than current version");
         }
-        
+
         // Execute any necessary state migrations here if migrating from specific versions
         // e.g. if current_version == 1 && new_version == 2 { ... migrate v1 state to v2 layout ... }
-        
-        env.storage().instance().set(&DataKey::ContractVersion, &new_version);
-        env.events().publish((symbol_short!("upgrade"), symbol_short!("migrate")), new_version);
+
+        env.storage()
+            .instance()
+            .set(&DataKey::ContractVersion, &new_version);
+        env.events().publish(
+            (symbol_short!("upgrade"), symbol_short!("migrate")),
+            new_version,
+        );
     }
-    
+
     pub fn version(env: &Env) -> u32 {
-        env.storage().instance().get(&DataKey::ContractVersion).unwrap_or(0)
+        env.storage()
+            .instance()
+            .get(&DataKey::ContractVersion)
+            .unwrap_or(0)
     }
 
     pub fn check_version(env: &Env, expected_version: u32) {
         let current = Self::version(env);
         if current != expected_version {
-            panic!("VersionMismatch: Expected contract version {} but found {}", expected_version, current);
+            panic!(
+                "VersionMismatch: Expected contract version {} but found {}",
+                expected_version, current
+            );
         }
     }
-
 
     pub fn is_paused(env: Env) -> bool {
         env.storage()

--- a/smartcontract/contracts/volatility_shield/src/test.rs
+++ b/smartcontract/contracts/volatility_shield/src/test.rs
@@ -29,7 +29,9 @@ fn test_init_stores_roles() {
     let treasury = Address::generate(&env);
 
     let guardians = soroban_sdk::vec![&env, admin.clone()];
-    client.init(&admin, &asset, &oracle, &treasury, &500u32, &guardians, &1u32);
+    client.init(
+        &admin, &asset, &oracle, &treasury, &500u32, &guardians, &1u32,
+    );
 
     assert_eq!(client.read_admin(), admin);
     assert_eq!(client.get_oracle(), oracle);
@@ -54,10 +56,26 @@ fn test_init_already_initialized() {
     let oracle = Address::generate(&env);
     let treasury = Address::generate(&env);
 
-    let result = client.try_init(&admin, &asset, &oracle, &treasury, &500u32, &soroban_sdk::vec![&env, admin.clone()], &1u32);
+    let result = client.try_init(
+        &admin,
+        &asset,
+        &oracle,
+        &treasury,
+        &500u32,
+        &soroban_sdk::vec![&env, admin.clone()],
+        &1u32,
+    );
     assert!(result.is_ok());
 
-    let result = client.try_init(&admin, &asset, &oracle, &treasury, &500u32, &soroban_sdk::vec![&env, admin.clone()], &1u32);
+    let result = client.try_init(
+        &admin,
+        &asset,
+        &oracle,
+        &treasury,
+        &500u32,
+        &soroban_sdk::vec![&env, admin.clone()],
+        &1u32,
+    );
     assert_eq!(result, Err(Ok(Error::AlreadyInitialized)));
 }
 
@@ -182,7 +200,9 @@ fn test_take_fees() {
     let treasury = Address::generate(&env);
 
     let guardians = soroban_sdk::vec![&env, admin.clone()];
-    client.init(&admin, &asset, &oracle, &treasury, &500u32, &guardians, &1u32);
+    client.init(
+        &admin, &asset, &oracle, &treasury, &500u32, &guardians, &1u32,
+    );
 
     let deposit_amount = 1000;
     let remaining = client.take_fees(&deposit_amount);
@@ -204,7 +224,10 @@ fn test_deposit_success() {
     let oracle = Address::generate(&env);
     let treasury = Address::generate(&env);
 
-    let guardians = soroban_sdk::vec![&env, admin.clone()]; client.init(&admin, &token_id, &oracle, &treasury, &0u32, &guardians, &1u32);
+    let guardians = soroban_sdk::vec![&env, admin.clone()];
+    client.init(
+        &admin, &token_id, &oracle, &treasury, &0u32, &guardians, &1u32,
+    );
 
     let user = Address::generate(&env);
     let deposit_amount = 1000;
@@ -232,7 +255,10 @@ fn test_withdraw_success() {
     let oracle = Address::generate(&env);
     let treasury = Address::generate(&env);
 
-    let guardians = soroban_sdk::vec![&env, admin.clone()]; client.init(&admin, &token_id, &oracle, &treasury, &0u32, &guardians, &1u32);
+    let guardians = soroban_sdk::vec![&env, admin.clone()];
+    client.init(
+        &admin, &token_id, &oracle, &treasury, &0u32, &guardians, &1u32,
+    );
     client.set_total_shares(&1000);
     client.set_total_assets(&5000);
 
@@ -289,7 +315,7 @@ fn test_rebalance_oracle_auth_accepted() {
     env.ledger().set_timestamp(12345);
     let allocations: Map<Address, i128> = Map::new(&env);
     client.set_oracle_data(&allocations, &env.ledger().timestamp());
-    
+
     // Propose Rebalance with threshold 1 -> immediate execution
     client.propose_action(&oracle, &ActionType::Rebalance(50u32));
 }
@@ -311,10 +337,10 @@ fn test_multisig_set_paused() {
     client.init(&admin, &asset, &oracle, &treasury, &0u32, &guardians, &2u32);
 
     let id = client.propose_action(&admin, &ActionType::SetPaused(true));
-    
+
     // One approval not enough
     assert!(!client.is_paused());
-    
+
     // Second approval triggers execution
     client.approve_action(&oracle, &id);
     assert!(client.is_paused());
@@ -353,7 +379,15 @@ fn test_multisig_unauthorized_propose() {
 
     let admin = Address::generate(&env);
     let guardians = soroban_sdk::vec![&env, admin.clone()];
-    client.init(&admin, &Address::generate(&env), &Address::generate(&env), &Address::generate(&env), &0, &guardians, &1);
+    client.init(
+        &admin,
+        &Address::generate(&env),
+        &Address::generate(&env),
+        &Address::generate(&env),
+        &0,
+        &guardians,
+        &1,
+    );
 
     let stranger = Address::generate(&env);
     let result = client.try_propose_action(&stranger, &ActionType::Rebalance(50u32));
@@ -387,9 +421,7 @@ fn test_guardian_crud() {
     client.remove_guardian(&guardian_2);
     assert_eq!(client.get_guardians().len(), 1);
     assert!(!client.get_guardians().contains(guardian_2));
-
 }
-
 
 #[cfg(test)]
 mod strategy_health_tests {
@@ -524,7 +556,8 @@ mod strategy_health_tests {
         env.mock_all_auths_allowing_non_root_auth();
 
         let token_admin = Address::generate(&env);
-        let (token_id, stellar_asset_client, token_client) = create_token_contract(&env, &token_admin);
+        let (token_id, stellar_asset_client, token_client) =
+            create_token_contract(&env, &token_admin);
 
         let contract_id = env.register_contract(None, VolatilityShield);
         let client = VolatilityShieldClient::new(&env, &contract_id);
@@ -534,7 +567,9 @@ mod strategy_health_tests {
         let oracle = Address::generate(&env);
         let treasury = Address::generate(&env);
         let guardians = soroban_sdk::vec![&env, admin.clone()];
-        client.init(&admin, &token_id, &oracle, &treasury, &0u32, &guardians, &1u32);
+        client.init(
+            &admin, &token_id, &oracle, &treasury, &0u32, &guardians, &1u32,
+        );
 
         let (mock_strategy_id, mock_client) = create_mock_strategy(&env);
         client.propose_action(&admin, &ActionType::AddStrategy(mock_strategy_id.clone()));
@@ -678,7 +713,7 @@ fn test_timelock_duration_setting() {
 
     // Set timelock duration to 100 seconds
     client.set_timelock_duration(&100);
-    
+
     // Verify it was set (we can't directly read it, but execution will respect it)
 }
 
@@ -760,7 +795,7 @@ fn test_timelock_with_multisig_approval() {
 
     // Propose action (threshold is 2, so it won't execute immediately)
     let proposal_id = client.propose_action(&admin, &ActionType::SetPaused(true));
-    
+
     // Try to approve immediately - should fail due to timelock
     let result = client.try_approve_action(&oracle, &proposal_id);
     assert_eq!(result, Err(Ok(Error::TimelockNotElapsed)));
@@ -865,7 +900,9 @@ fn test_withdraw_below_threshold_processes_immediately() {
     let oracle = Address::generate(&env);
     let treasury = Address::generate(&env);
     let guardians = soroban_sdk::vec![&env, admin.clone()];
-    client.init(&admin, &token_id, &oracle, &treasury, &0u32, &guardians, &1u32);
+    client.init(
+        &admin, &token_id, &oracle, &treasury, &0u32, &guardians, &1u32,
+    );
 
     // Set queue threshold to 1000
     client.set_withdraw_queue_threshold(&1000);
@@ -901,7 +938,9 @@ fn test_withdraw_above_threshold_queues() {
     let oracle = Address::generate(&env);
     let treasury = Address::generate(&env);
     let guardians = soroban_sdk::vec![&env, admin.clone()];
-    client.init(&admin, &token_id, &oracle, &treasury, &0u32, &guardians, &1u32);
+    client.init(
+        &admin, &token_id, &oracle, &treasury, &0u32, &guardians, &1u32,
+    );
 
     // Set queue threshold to 1000
     client.set_withdraw_queue_threshold(&1000);
@@ -939,7 +978,9 @@ fn test_process_withdraw_queue() {
     let oracle = Address::generate(&env);
     let treasury = Address::generate(&env);
     let guardians = soroban_sdk::vec![&env, admin.clone()];
-    client.init(&admin, &token_id, &oracle, &treasury, &0u32, &guardians, &1u32);
+    client.init(
+        &admin, &token_id, &oracle, &treasury, &0u32, &guardians, &1u32,
+    );
 
     // Set queue threshold
     client.set_withdraw_queue_threshold(&1000);
@@ -980,7 +1021,9 @@ fn test_cancel_withdraw() {
     let oracle = Address::generate(&env);
     let treasury = Address::generate(&env);
     let guardians = soroban_sdk::vec![&env, admin.clone()];
-    client.init(&admin, &token_id, &oracle, &treasury, &0u32, &guardians, &1u32);
+    client.init(
+        &admin, &token_id, &oracle, &treasury, &0u32, &guardians, &1u32,
+    );
 
     // Set queue threshold
     client.set_withdraw_queue_threshold(&1000);
@@ -1024,7 +1067,9 @@ fn test_cannot_queue_multiple_withdrawals() {
     let oracle = Address::generate(&env);
     let treasury = Address::generate(&env);
     let guardians = soroban_sdk::vec![&env, admin.clone()];
-    client.init(&admin, &token_id, &oracle, &treasury, &0u32, &guardians, &1u32);
+    client.init(
+        &admin, &token_id, &oracle, &treasury, &0u32, &guardians, &1u32,
+    );
 
     client.set_withdraw_queue_threshold(&1000);
 
@@ -1101,7 +1146,9 @@ fn test_withdrawal_queue_fifo_order() {
     let oracle = Address::generate(&env);
     let treasury = Address::generate(&env);
     let guardians = soroban_sdk::vec![&env, admin.clone()];
-    client.init(&admin, &token_id, &oracle, &treasury, &0u32, &guardians, &1u32);
+    client.init(
+        &admin, &token_id, &oracle, &treasury, &0u32, &guardians, &1u32,
+    );
 
     client.set_withdraw_queue_threshold(&1000);
 
@@ -1148,7 +1195,9 @@ fn test_withdrawal_queue_full_lifecycle() {
     let oracle = Address::generate(&env);
     let treasury = Address::generate(&env);
     let guardians = soroban_sdk::vec![&env, admin.clone()];
-    client.init(&admin, &token_id, &oracle, &treasury, &0u32, &guardians, &1u32);
+    client.init(
+        &admin, &token_id, &oracle, &treasury, &0u32, &guardians, &1u32,
+    );
 
     client.set_withdraw_queue_threshold(&1000);
 
@@ -1181,9 +1230,21 @@ fn test_withdrawal_queue_full_lifecycle() {
     assert_eq!(client.balance(&user), 800);
     assert_eq!(token_client.balance(&user), 1500);
     assert_eq!(client.get_pending_withdrawals().len(), 0);
-
 }
 // ── Oracle Allocation Validation Tests ─────────────────────────
+//
+// All tests that supply a non-empty allocation map first register the strategy
+// addresses via propose_action (AddStrategy) so the new on-chain registry
+// membership guard in validate_allocations is satisfied.  Tests that
+// specifically exercise the ZeroAddressStrategy path intentionally skip
+// registration.
+
+/// Helper: register one strategy address and return it.
+fn register_strategy(env: &Env, client: &VolatilityShieldClient, admin: &Address) -> Address {
+    let strategy = Address::generate(env);
+    client.propose_action(admin, &ActionType::AddStrategy(strategy.clone()));
+    strategy
+}
 
 #[test]
 fn test_valid_allocation_sum_to_100_percent() {
@@ -1201,9 +1262,10 @@ fn test_valid_allocation_sum_to_100_percent() {
     let guardians = soroban_sdk::vec![&env, admin.clone()];
     client.init(&admin, &asset, &oracle, &treasury, &0u32, &guardians, &1u32);
 
-    let strategy1 = Address::generate(&env);
-    let strategy2 = Address::generate(&env);
-    let strategy3 = Address::generate(&env);
+    // Register all three strategies before submitting oracle data.
+    let strategy1 = register_strategy(&env, &client, &admin);
+    let strategy2 = register_strategy(&env, &client, &admin);
+    let strategy3 = register_strategy(&env, &client, &admin);
 
     let mut allocations: Map<Address, i128> = Map::new(&env);
     allocations.set(strategy1, 3000); // 30%
@@ -1231,6 +1293,7 @@ fn test_empty_allocation_accepted() {
     let guardians = soroban_sdk::vec![&env, admin.clone()];
     client.init(&admin, &asset, &oracle, &treasury, &0u32, &guardians, &1u32);
 
+    // An empty map has no addresses to register — the sum is 0, which is allowed.
     let allocations: Map<Address, i128> = Map::new(&env);
 
     env.ledger().set_timestamp(1000);
@@ -1254,13 +1317,12 @@ fn test_allocation_sum_less_than_100_percent_rejected() {
     let guardians = soroban_sdk::vec![&env, admin.clone()];
     client.init(&admin, &asset, &oracle, &treasury, &0u32, &guardians, &1u32);
 
-    let strategy1 = Address::generate(&env);
-    let strategy2 = Address::generate(&env);
+    let strategy1 = register_strategy(&env, &client, &admin);
+    let strategy2 = register_strategy(&env, &client, &admin);
 
     let mut allocations: Map<Address, i128> = Map::new(&env);
     allocations.set(strategy1, 3000); // 30%
-    allocations.set(strategy2, 5000); // 50%
-    // Total: 80% (should be 100%)
+    allocations.set(strategy2, 5000); // 50% — total 80%, must be 100%.
 
     env.ledger().set_timestamp(1000);
     let result = client.try_set_oracle_data(&allocations, &1000);
@@ -1283,15 +1345,14 @@ fn test_allocation_sum_greater_than_100_percent_rejected() {
     let guardians = soroban_sdk::vec![&env, admin.clone()];
     client.init(&admin, &asset, &oracle, &treasury, &0u32, &guardians, &1u32);
 
-    let strategy1 = Address::generate(&env);
-    let strategy2 = Address::generate(&env);
-    let strategy3 = Address::generate(&env);
+    let strategy1 = register_strategy(&env, &client, &admin);
+    let strategy2 = register_strategy(&env, &client, &admin);
+    let strategy3 = register_strategy(&env, &client, &admin);
 
     let mut allocations: Map<Address, i128> = Map::new(&env);
     allocations.set(strategy1, 4000); // 40%
     allocations.set(strategy2, 5000); // 50%
-    allocations.set(strategy3, 2500); // 25%
-    // Total: 115% (should be 100%)
+    allocations.set(strategy3, 2500); // 25% — total 115%, must be 100%.
 
     env.ledger().set_timestamp(1000);
     let result = client.try_set_oracle_data(&allocations, &1000);
@@ -1314,18 +1375,17 @@ fn test_negative_allocation_rejected() {
     let guardians = soroban_sdk::vec![&env, admin.clone()];
     client.init(&admin, &asset, &oracle, &treasury, &0u32, &guardians, &1u32);
 
-    let strategy1 = Address::generate(&env);
-    let strategy2 = Address::generate(&env);
+    let strategy1 = register_strategy(&env, &client, &admin);
+    let strategy2 = register_strategy(&env, &client, &admin);
 
     let mut allocations: Map<Address, i128> = Map::new(&env);
-    allocations.set(strategy1, -1000); // -10% (invalid)
+    allocations.set(strategy1, -1000); // -10% — invalid.
     allocations.set(strategy2, 11000); // 110%
 
     env.ledger().set_timestamp(1000);
     let result = client.try_set_oracle_data(&allocations, &1000);
     assert_eq!(result, Err(Ok(Error::NegativeAllocation)));
 }
-
 
 #[test]
 fn test_single_strategy_100_percent_allocation() {
@@ -1343,10 +1403,10 @@ fn test_single_strategy_100_percent_allocation() {
     let guardians = soroban_sdk::vec![&env, admin.clone()];
     client.init(&admin, &asset, &oracle, &treasury, &0u32, &guardians, &1u32);
 
-    let strategy1 = Address::generate(&env);
+    let strategy1 = register_strategy(&env, &client, &admin);
 
     let mut allocations: Map<Address, i128> = Map::new(&env);
-    allocations.set(strategy1, 10000); // 100%
+    allocations.set(strategy1, 10000); // 100% to one strategy — valid.
 
     env.ledger().set_timestamp(1000);
     let result = client.try_set_oracle_data(&allocations, &1000);
@@ -1369,14 +1429,75 @@ fn test_multiple_negative_allocations_rejected() {
     let guardians = soroban_sdk::vec![&env, admin.clone()];
     client.init(&admin, &asset, &oracle, &treasury, &0u32, &guardians, &1u32);
 
-    let strategy1 = Address::generate(&env);
-    let strategy2 = Address::generate(&env);
+    let strategy1 = register_strategy(&env, &client, &admin);
+    let strategy2 = register_strategy(&env, &client, &admin);
 
     let mut allocations: Map<Address, i128> = Map::new(&env);
-    allocations.set(strategy1, -5000); // -50%
+    allocations.set(strategy1, -5000); // -50% — invalid.
     allocations.set(strategy2, -5000); // -50%
 
     env.ledger().set_timestamp(1000);
     let result = client.try_set_oracle_data(&allocations, &1000);
     assert_eq!(result, Err(Ok(Error::NegativeAllocation)));
+}
+
+/// An allocation referencing an address that was never registered as a strategy
+/// must be rejected with `ZeroAddressStrategy`. This is the Soroban-native
+/// equivalent of the EVM zero-address guard — the oracle must not be able to
+/// direct funds to an arbitrary or attacker-controlled address.
+#[test]
+fn test_unregistered_strategy_address_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, VolatilityShield);
+    let client = VolatilityShieldClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let asset = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let treasury = Address::generate(&env);
+
+    let guardians = soroban_sdk::vec![&env, admin.clone()];
+    client.init(&admin, &asset, &oracle, &treasury, &0u32, &guardians, &1u32);
+
+    // Intentionally do NOT register this address — simulates a rogue/zero address.
+    let rogue = Address::generate(&env);
+
+    let mut allocations: Map<Address, i128> = Map::new(&env);
+    allocations.set(rogue, 10000);
+
+    env.ledger().set_timestamp(1000);
+    let result = client.try_set_oracle_data(&allocations, &1000);
+    assert_eq!(result, Err(Ok(Error::ZeroAddressStrategy)));
+}
+
+/// Partially-registered allocation: one valid strategy + one rogue strategy.
+/// The guard must catch the unregistered entry regardless of ordering.
+#[test]
+fn test_partially_unregistered_allocation_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, VolatilityShield);
+    let client = VolatilityShieldClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let asset = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let treasury = Address::generate(&env);
+
+    let guardians = soroban_sdk::vec![&env, admin.clone()];
+    client.init(&admin, &asset, &oracle, &treasury, &0u32, &guardians, &1u32);
+
+    let valid_strategy = register_strategy(&env, &client, &admin);
+    let rogue_strategy = Address::generate(&env); // not registered
+
+    let mut allocations: Map<Address, i128> = Map::new(&env);
+    allocations.set(valid_strategy, 5000); // 50%
+    allocations.set(rogue_strategy, 5000); // 50% — but address is not in registry
+
+    env.ledger().set_timestamp(1000);
+    let result = client.try_set_oracle_data(&allocations, &1000);
+    assert_eq!(result, Err(Ok(Error::ZeroAddressStrategy)));
 }


### PR DESCRIPTION
Closes #230 

This PR implements strict integrity and logical correctness validations on oracle allocation data pushed to the 

VolatilityShield
 vault during rebalance cycles. These constraints prevent malicious or misconfigured oracles from directing funds into unregistered strategies, stealing funds through negative allocations, or breaking the vault's 100% distribution invariant.

🛠 Technical Changes
O(n) Validation Pass (

validate_allocations
):
Zero-Address Strategy Guard: Added a check to explicitly verify every strategy address supplied by the oracle exists in the internal, governance-approved registry. Unregistered ("rogue") addresses are rejected with ZeroAddressStrategy.
Non-Negative Value Guard: Asserts no allocation explicitly carries a negative basis point value (NegativeAllocation).
100% Distribution Guard: Accumulates total allocation dynamically, saturates overflow, and strictly enforces the sum equals 10000 (100%), or 0 for an intentional reset scenario (InvalidAllocationSum).
Test Suite Modernization:
Registered test strategies via 

propose_action(AddStrategy)
 inside test setups to satisfy the new registry membership guard.
Added specific unit tests testing both fully unregistered and partially registered rogue strategies pushed via oracle data.
Cleaned up ~200 lines of orphaned boilerplate duplicate tests left at the bottom of the 
