### PR TITLE
feat: stale data indicators, skeleton loading & CSP headers

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { headers } from "next/headers";
 import "./globals.css";
 import { Providers } from "./providers";
 import { DashboardLayout } from "@/components/dashboard-layout";
@@ -21,15 +22,18 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  // Read the nonce injected by middleware for CSP nonce-based script loading
+  const nonce = (await headers()).get("x-nonce") ?? undefined;
+
   return (
     <html lang="en" suppressHydrationWarning>
       <body>
-        <Providers>
+        <Providers nonce={nonce}>
           <ErrorBoundary>
             <DashboardLayout>{children}</DashboardLayout>
           </ErrorBoundary>

--- a/frontend/app/providers.tsx
+++ b/frontend/app/providers.tsx
@@ -12,9 +12,14 @@ import { Toaster } from "sonner";
 
 import { I18nProvider } from "@/lib/i18n-context";
 
-export function Providers({ children }: { children: ReactNode }) {
+interface ProvidersProps {
+  children: ReactNode;
+  nonce?: string;
+}
+
+export function Providers({ children, nonce }: ProvidersProps) {
   return (
-    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+    <ThemeProvider attribute="class" defaultTheme="system" enableSystem nonce={nonce}>
       <I18nProvider>
         <FreighterProvider>
           <NetworkProvider>

--- a/frontend/components/StaleBadge.tsx
+++ b/frontend/components/StaleBadge.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { AlertCircle, CheckCircle2, RefreshCw } from "lucide-react";
+import { getTimeAgo } from "@/hooks/use-stale-data";
+
+interface StaleBadgeProps {
+  lastFetchedAt: Date | null;
+  isStale: boolean;
+  onRefresh?: () => void;
+  refreshing?: boolean;
+}
+
+/**
+ * Displays a staleness badge showing when data was last fetched.
+ * Turns amber when data is stale and provides an optional refresh action.
+ */
+export function StaleBadge({
+  lastFetchedAt,
+  isStale,
+  onRefresh,
+  refreshing = false,
+}: StaleBadgeProps) {
+  const [timeAgo, setTimeAgo] = useState(() => getTimeAgo(lastFetchedAt));
+
+  // Update the "time ago" label every 30 seconds
+  useEffect(() => {
+    setTimeAgo(getTimeAgo(lastFetchedAt));
+    const interval = setInterval(() => {
+      setTimeAgo(getTimeAgo(lastFetchedAt));
+    }, 30_000);
+    return () => clearInterval(interval);
+  }, [lastFetchedAt]);
+
+  if (!lastFetchedAt) return null;
+
+  return (
+    <div
+      className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium transition-colors ${
+        isStale
+          ? "bg-amber-500/10 text-amber-500 border border-amber-500/20"
+          : "bg-green-500/10 text-green-500 border border-green-500/20"
+      }`}
+      title={`Last updated: ${lastFetchedAt.toLocaleTimeString()}`}
+    >
+      {isStale ? (
+        <AlertCircle className="h-3 w-3 shrink-0" />
+      ) : (
+        <CheckCircle2 className="h-3 w-3 shrink-0" />
+      )}
+      <span>{isStale ? "Stale" : "Live"} · {timeAgo}</span>
+      {onRefresh && (
+        <button
+          onClick={onRefresh}
+          disabled={refreshing}
+          className="ml-0.5 rounded-full p-0.5 hover:bg-current/10 transition-colors disabled:opacity-50"
+          aria-label="Refresh data"
+        >
+          <RefreshCw className={`h-3 w-3 ${refreshing ? "animate-spin" : ""}`} />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/transaction-list.tsx
+++ b/frontend/components/transaction-list.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, useCallback, useMemo } from 'react';
+import { useEffect, useCallback, useMemo } from 'react';
 import {
   ArrowUpFromLine,
   ArrowDownToLine,
@@ -14,6 +14,9 @@ import { formatNumber } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import type { ColumnDef } from '@tanstack/react-table';
 import ReactTableVirtualized from '@/app/components/VirtualizedTable';
+import { useStaleData } from '@/hooks/use-stale-data';
+import { StaleBadge } from '@/components/StaleBadge';
+import { TransactionListSkeleton } from '@/components/ui/skeleton';
 
 /**
  * Builds a CSV string from a list of transactions, mirroring the UI table columns.
@@ -45,24 +48,24 @@ function buildTransactionCsv(transactions: Transaction[]): string {
  */
 export function TransactionList() {
   const { connected, address } = useWallet();
-  const [transactions, setTransactions] = useState<Transaction[]>([]);
-  const [loading, setLoading] = useState(false);
+  const { state, setData, setLoading, setError } = useStaleData<Transaction[]>(5 * 60 * 1000);
+  const transactions = state.data ?? [];
+
+  const loadHistory = useCallback(async () => {
+    if (!connected || !address) return;
+    setLoading(true);
+    try {
+      const history = await fetchTransactionHistory(address);
+      setData(history);
+    } catch (error) {
+      console.error('Failed to fetch history:', error);
+      setError(error instanceof Error ? error.message : 'Failed to load transactions');
+    }
+  }, [connected, address, setData, setLoading, setError]);
 
   useEffect(() => {
-    async function loadHistory() {
-      if (!connected || !address) return;
-      setLoading(true);
-      try {
-        const history = await fetchTransactionHistory(address);
-        setTransactions(history);
-      } catch (error) {
-        console.error('Failed to fetch history:', error);
-      } finally {
-        setLoading(false);
-      }
-    }
     loadHistory();
-  }, [connected, address]);
+  }, [loadHistory]);
 
   const handleDownloadCsv = useCallback(() => {
     if (!transactions.length) return;
@@ -156,31 +159,36 @@ export function TransactionList() {
           <Clock className="w-6 h-6 text-primary" />
           <h2 className="text-xl font-semibold">Recent Activity</h2>
         </div>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={handleDownloadCsv}
-          disabled={loading || transactions.length === 0}
-          aria-label="Download transaction history as CSV"
-        >
-          <Download className="w-4 h-4" />
-          <span className="hidden sm:inline">Download CSV</span>
-        </Button>
+        <div className="flex items-center gap-2">
+          <StaleBadge
+            lastFetchedAt={state.lastFetchedAt}
+            isStale={state.isStale}
+            onRefresh={loadHistory}
+            refreshing={state.loading}
+          />
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={handleDownloadCsv}
+            disabled={state.loading || transactions.length === 0}
+            aria-label="Download transaction history as CSV"
+          >
+            <Download className="w-4 h-4" />
+            <span className="hidden sm:inline">Download CSV</span>
+          </Button>
+        </div>
       </div>
 
       <div className="space-y-4">
-        {loading ? (
-          <div className="text-center py-8 text-muted-foreground animate-pulse">
-            Loading activity...
-          </div>
+        {state.loading ? (
+          <TransactionListSkeleton rows={3} />
         ) : transactions.length === 0 ? (
           <div className="text-center py-8 text-muted-foreground">
             No recent activity found.
           </div>
         ) : (
-          
-           <ReactTableVirtualized columns={columns} data={transactions} />
+          <ReactTableVirtualized columns={columns} data={transactions} />
         )}
       </div>
     </div>

--- a/frontend/components/ui/skeleton.tsx
+++ b/frontend/components/ui/skeleton.tsx
@@ -1,0 +1,65 @@
+import { cn } from "@/lib/utils";
+
+interface SkeletonProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function Skeleton({ className, ...props }: SkeletonProps) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      {...props}
+    />
+  );
+}
+
+/** Skeleton for a metric card (title + value + subtitle) */
+export function MetricCardSkeleton() {
+  return (
+    <div className="flex flex-col gap-2 p-4 rounded-lg bg-muted/50">
+      <Skeleton className="h-4 w-24" />
+      <Skeleton className="h-8 w-32" />
+      <Skeleton className="h-3 w-16" />
+    </div>
+  );
+}
+
+/** Skeleton for the vault overview card */
+export function VaultOverviewSkeleton() {
+  return (
+    <div className="rounded-lg border bg-card p-6 shadow-sm">
+      <div className="flex items-center justify-between mb-6">
+        <Skeleton className="h-6 w-40" />
+        <Skeleton className="h-8 w-8 rounded-lg" />
+      </div>
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <MetricCardSkeleton key={i} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** Skeleton for a transaction row */
+export function TransactionRowSkeleton() {
+  return (
+    <div className="flex items-center gap-4 py-3 border-b last:border-0">
+      <Skeleton className="h-8 w-8 rounded-full shrink-0" />
+      <div className="flex-1 space-y-1.5">
+        <Skeleton className="h-4 w-32" />
+        <Skeleton className="h-3 w-24" />
+      </div>
+      <Skeleton className="h-4 w-20" />
+    </div>
+  );
+}
+
+/** Skeleton for the transaction list */
+export function TransactionListSkeleton({ rows = 3 }: { rows?: number }) {
+  return (
+    <div className="space-y-0">
+      {Array.from({ length: rows }).map((_, i) => (
+        <TransactionRowSkeleton key={i} />
+      ))}
+    </div>
+  );
+}

--- a/frontend/components/vault-overview-card.tsx
+++ b/frontend/components/vault-overview-card.tsx
@@ -1,12 +1,15 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { Shield, TrendingUp, TrendingDown, RefreshCw, Wallet } from "lucide-react";
+import { Shield, TrendingUp, RefreshCw, Wallet } from "lucide-react";
 import { useWallet } from "@/hooks/use-wallet";
 import { useNetwork } from "@/app/context/NetworkContext";
 import { useCurrency } from "@/app/context/CurrencyContext";
 import { fetchVaultData, VaultMetrics } from "@/lib/stellar";
 import { formatNumber } from "@/lib/utils";
+import { useStaleData } from "@/hooks/use-stale-data";
+import { StaleBadge } from "@/components/StaleBadge";
+import { VaultOverviewSkeleton } from "@/components/ui/skeleton";
 
 const CONTRACT_ID = process.env.NEXT_PUBLIC_CONTRACT_ID || "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC";
 
@@ -14,8 +17,7 @@ export function VaultOverviewCard() {
   const { connected, address } = useWallet();
   const { network } = useNetwork();
   const { format } = useCurrency();
-  const [metrics, setMetrics] = useState<VaultMetrics | null>(null);
-  const [loading, setLoading] = useState(true);
+  const { state, setData, setLoading, setError } = useStaleData<VaultMetrics>(5 * 60 * 1000);
   const [refreshing, setRefreshing] = useState(false);
 
   const loadVaultData = useCallback(async (isRefresh = false) => {
@@ -24,21 +26,17 @@ export function VaultOverviewCard() {
     } else {
       setLoading(true);
     }
-    
+
     try {
-      const data = await fetchVaultData(
-        CONTRACT_ID,
-        address,
-        network
-      );
-      setMetrics(data);
+      const data = await fetchVaultData(CONTRACT_ID, address, network);
+      setData(data);
     } catch (error) {
       console.error("Failed to fetch vault data:", error);
+      setError(error instanceof Error ? error.message : "Failed to load vault data");
     } finally {
-      setLoading(false);
       setRefreshing(false);
     }
-  }, [address, network]);
+  }, [address, network, setData, setLoading, setError]);
 
   useEffect(() => {
     loadVaultData();
@@ -48,17 +46,11 @@ export function VaultOverviewCard() {
     loadVaultData(true);
   };
 
-  if (loading) {
-    return (
-      <div className="rounded-lg border bg-card p-6 shadow-sm">
-        <div className="flex items-center justify-center py-8">
-          <RefreshCw className="w-6 h-6 animate-spin text-primary" />
-          <span className="ml-2 text-muted-foreground">Loading vault data...</span>
-        </div>
-      </div>
-    );
+  if (state.loading) {
+    return <VaultOverviewSkeleton />;
   }
 
+  const metrics = state.data;
   const totalAssets = parseFloat(metrics?.totalAssets || "0") / 1e7;
   const totalShares = parseFloat(metrics?.totalShares || "0") / 1e7;
   const sharePrice = parseFloat(metrics?.sharePrice || "1.0000000");
@@ -71,14 +63,22 @@ export function VaultOverviewCard() {
           <Shield className="w-6 h-6 text-primary" />
           <h2 className="text-xl font-semibold">Vault Overview</h2>
         </div>
-        <button
-          onClick={handleRefresh}
-          disabled={refreshing}
-          className="p-2 rounded-lg hover:bg-accent transition-colors disabled:opacity-50"
-          title="Refresh data"
-        >
-          <RefreshCw className={`w-4 h-4 ${refreshing ? "animate-spin" : ""}`} />
-        </button>
+        <div className="flex items-center gap-2">
+          <StaleBadge
+            lastFetchedAt={state.lastFetchedAt}
+            isStale={state.isStale}
+            onRefresh={handleRefresh}
+            refreshing={refreshing}
+          />
+          <button
+            onClick={handleRefresh}
+            disabled={refreshing}
+            className="p-2 rounded-lg hover:bg-accent transition-colors disabled:opacity-50"
+            title="Refresh data"
+          >
+            <RefreshCw className={`w-4 h-4 ${refreshing ? "animate-spin" : ""}`} />
+          </button>
+        </div>
       </div>
 
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
@@ -111,6 +111,12 @@ export function VaultOverviewCard() {
           icon={<Wallet className="w-4 h-4 text-muted-foreground" />}
         />
       </div>
+
+      {state.error && (
+        <div className="mt-4 p-3 rounded-lg bg-destructive/10 text-destructive text-sm">
+          {state.error} — showing last known data.
+        </div>
+      )}
 
       {!connected && (
         <div className="mt-4 p-4 rounded-lg bg-muted/50 text-sm text-muted-foreground">

--- a/frontend/hooks/use-stale-data.ts
+++ b/frontend/hooks/use-stale-data.ts
@@ -1,0 +1,72 @@
+"use client";
+
+import { useState, useCallback, useRef } from "react";
+
+export interface StaleDataState<T> {
+  data: T | null;
+  loading: boolean;
+  error: string | null;
+  lastFetchedAt: Date | null;
+  isStale: boolean;
+}
+
+/**
+ * Hook to track data staleness.
+ * @param staleThresholdMs - Time in ms after which data is considered stale (default: 5 minutes)
+ */
+export function useStaleData<T>(staleThresholdMs = 5 * 60 * 1000) {
+  const [state, setState] = useState<StaleDataState<T>>({
+    data: null,
+    loading: false,
+    error: null,
+    lastFetchedAt: null,
+    isStale: false,
+  });
+
+  const staleTimerRef = useRef<NodeJS.Timeout | null>(null);
+
+  const setData = useCallback(
+    (data: T) => {
+      const now = new Date();
+
+      if (staleTimerRef.current) clearTimeout(staleTimerRef.current);
+
+      setState({
+        data,
+        loading: false,
+        error: null,
+        lastFetchedAt: now,
+        isStale: false,
+      });
+
+      // Mark as stale after threshold
+      staleTimerRef.current = setTimeout(() => {
+        setState((prev) => ({ ...prev, isStale: true }));
+      }, staleThresholdMs);
+    },
+    [staleThresholdMs]
+  );
+
+  const setLoading = useCallback((loading: boolean) => {
+    setState((prev) => ({ ...prev, loading }));
+  }, []);
+
+  const setError = useCallback((error: string | null) => {
+    setState((prev) => ({ ...prev, loading: false, error }));
+  }, []);
+
+  return { state, setData, setLoading, setError };
+}
+
+/**
+ * Returns a human-readable "time ago" string from a Date.
+ */
+export function getTimeAgo(date: Date | null): string {
+  if (!date) return "";
+  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ago`;
+}

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,0 +1,104 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+/**
+ * Generates a cryptographically random nonce for CSP using the Web Crypto API
+ * (compatible with the Edge Runtime).
+ */
+function generateNonce(): string {
+  const array = new Uint8Array(16);
+  crypto.getRandomValues(array);
+  return Buffer.from(array).toString("base64");
+}
+
+/**
+ * Builds a strict Content-Security-Policy header value.
+ * Uses a per-request nonce for inline scripts to prevent XSS.
+ */
+function buildCsp(nonce: string): string {
+  const directives: Record<string, string> = {
+    "default-src": "'self'",
+    "script-src": [
+      "'self'",
+      `'nonce-${nonce}'`,
+      // Next.js requires 'strict-dynamic' for its runtime chunks
+      "'strict-dynamic'",
+    ].join(" "),
+    "style-src": [
+      "'self'",
+      // Tailwind / inline styles injected by Next.js
+      "'unsafe-inline'",
+    ].join(" "),
+    "img-src": [
+      "'self'",
+      "data:",
+      "blob:",
+      // CoinGecko asset images
+      "https://assets.coingecko.com",
+    ].join(" "),
+    "font-src": "'self'",
+    "connect-src": [
+      "'self'",
+      // Stellar network endpoints
+      "https://horizon.stellar.org",
+      "https://horizon-testnet.stellar.org",
+      "https://horizon-futurenet.stellar.org",
+      "https://rpc.mainnet.stellar.org",
+      "https://rpc.testnet.stellar.org",
+      "https://rpc-futurenet.stellar.org",
+      // CoinGecko price API
+      "https://api.coingecko.com",
+    ].join(" "),
+    "frame-src": "'none'",
+    "object-src": "'none'",
+    "base-uri": "'self'",
+    "form-action": "'self'",
+    "upgrade-insecure-requests": "",
+  };
+
+  return Object.entries(directives)
+    .map(([key, value]) => (value ? `${key} ${value}` : key))
+    .join("; ");
+}
+
+export function middleware(request: NextRequest) {
+  const nonce = generateNonce();
+  const csp = buildCsp(nonce);
+
+  const requestHeaders = new Headers(request.headers);
+  // Pass nonce to the page so Next.js can inject it into <script> tags
+  requestHeaders.set("x-nonce", nonce);
+  requestHeaders.set("content-security-policy", csp);
+
+  const response = NextResponse.next({
+    request: { headers: requestHeaders },
+  });
+
+  response.headers.set("content-security-policy", csp);
+  response.headers.set("x-frame-options", "DENY");
+  response.headers.set("x-content-type-options", "nosniff");
+  response.headers.set("referrer-policy", "strict-origin-when-cross-origin");
+  response.headers.set(
+    "permissions-policy",
+    "camera=(), microphone=(), geolocation=()"
+  );
+  response.headers.set(
+    "strict-transport-security",
+    "max-age=63072000; includeSubDomains; preload"
+  );
+
+  return response;
+}
+
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except:
+     * - _next/static (static files)
+     * - _next/image (image optimization)
+     * - favicon.ico
+     * - public folder assets
+     */
+    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+  ],
+};

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -5,6 +5,8 @@ const nextConfig = {
     domains: [],
     unoptimized: false,
   },
+  // Security headers are now managed by middleware.ts (CSP with nonce support).
+  // Keeping static fallback headers here for environments that bypass middleware.
   async headers() {
     return [
       {


### PR DESCRIPTION

## Summary

This PR implements two frontend issues:

Fixes: #248  [FE-39] Stale Data Indicators & Graceful Degradation
Fixes: #254  [FE-44a] Security Headers — CSP Configuration

---

## Changes

### #248 — Stale Data Indicators & Graceful Degradation

- Added `frontend/hooks/use-stale-data.ts` — a generic hook that tracks `lastFetchedAt` timestamp and marks data as stale after a configurable threshold (default 5 minutes).
- Added `frontend/components/StaleBadge.tsx` — a visual badge that shows "Live · Xs ago" (green) or "Stale · Xm ago" (amber) with an inline refresh button.
- Added `frontend/components/ui/skeleton.tsx` — skeleton loading components (`Skeleton`, `MetricCardSkeleton`, `VaultOverviewSkeleton`, `TransactionListSkeleton`) replacing spinner-only loading states.
- Updated `VaultOverviewCard` to use `useStaleData`, render `VaultOverviewSkeleton` during initial load, display `StaleBadge`, and surface fetch errors gracefully while preserving last known data.
- Updated `TransactionList` to use `useStaleData`, render `TransactionListSkeleton` during load, and show `StaleBadge` with inline refresh.

### #254 — Security Headers — CSP Configuration

- Added `frontend/middleware.ts` — Next.js middleware that generates a per-request cryptographic nonce (Web Crypto API, Edge Runtime compatible) and sets a strict `Content-Security-Policy` header whitelisting Stellar RPC/Horizon endpoints and CoinGecko API.
- Updated `frontend/app/layout.tsx` to read the `x-nonce` header injected by middleware and pass it to providers for nonce-based script loading.
- Updated `frontend/app/providers.tsx` to accept and forward the `nonce` prop to `ThemeProvider`.
- Updated `frontend/next.config.mjs` with a comment clarifying that security headers are now managed by middleware.

---

## Checks

- `npm run build` — passes with exit code 0
