### PR TITLE
feat(SC-26): add consecutive_failures strike counter to StrategyHealth

### DIFF
--- a/smartcontract/contracts/volatility_shield/src/lib.rs
+++ b/smartcontract/contracts/volatility_shield/src/lib.rs
@@ -69,6 +69,8 @@ pub enum DataKey {
     WithdrawQueueThreshold,
     PendingWithdrawals,
     StrategyHealth(Address),
+    /// Admin-configurable consecutive-failure threshold (default: 3).
+    MaxConsecutiveFailures,
     TimelockDuration,
     GovernanceToken,
     AssetBalance(Address, Address),
@@ -124,6 +126,10 @@ pub struct StrategyHealth {
     pub last_known_balance: i128,
     pub last_check_timestamp: u64,
     pub is_healthy: bool,
+    /// Number of consecutive failed balance checks.
+    /// Resets to 0 on every successful check.
+    /// When this reaches `MaxConsecutiveFailures` the strategy is auto-flagged.
+    pub consecutive_failures: u32,
 }
 
 // ─────────────────────────────────────────────
@@ -1570,6 +1576,7 @@ impl VolatilityShield {
             last_known_balance: 0,
             last_check_timestamp: env.ledger().timestamp(),
             is_healthy: true,
+            consecutive_failures: 0,
         };
         env.storage().instance().set(&health_key, &default_health);
 
@@ -1744,6 +1751,12 @@ impl VolatilityShield {
             return Err(Error::NoStrategies);
         }
 
+        let max_failures: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MaxConsecutiveFailures)
+            .unwrap_or(3);
+
         let mut unhealthy_strategies = Vec::new(&env);
         let current_time = env.ledger().timestamp();
 
@@ -1770,7 +1783,7 @@ impl VolatilityShield {
 
             // Get current health data
             let health_key = DataKey::StrategyHealth(strategy_addr.clone());
-            let current_health =
+            let mut current_health: StrategyHealth =
                 env.storage()
                     .instance()
                     .get(&health_key)
@@ -1778,6 +1791,7 @@ impl VolatilityShield {
                         last_known_balance: expected_balance,
                         last_check_timestamp: current_time,
                         is_healthy: true,
+                        consecutive_failures: 0,
                     });
 
             // Check if strategy is unhealthy (significant deviation from expected)
@@ -1790,24 +1804,31 @@ impl VolatilityShield {
                 false
             };
 
-            let is_healthy = !balance_deviation;
+            if balance_deviation {
+                // ── Failed check: increment strike counter ───────────────
+                current_health.consecutive_failures =
+                    current_health.consecutive_failures.saturating_add(1);
 
-            // Update health data if changed
-            if is_healthy != current_health.is_healthy
-                || actual_balance != current_health.last_known_balance
-            {
-                let new_health = StrategyHealth {
-                    last_known_balance: actual_balance,
-                    last_check_timestamp: current_time,
-                    is_healthy,
-                };
-                env.storage().instance().set(&health_key, &new_health);
-            }
+                if current_health.consecutive_failures >= max_failures {
+                    // Auto-flag after reaching the threshold
+                    current_health.is_healthy = false;
+                    env.events().publish(
+                        (symbol_short!("StrategyF"), strategy_addr.clone()),
+                        current_time,
+                    );
+                }
 
-            // If unhealthy, add to list for flagging
-            if !is_healthy {
                 unhealthy_strategies.push_back(strategy_addr.clone());
+            } else {
+                // ── Successful check: reset strike counter ───────────────
+                current_health.consecutive_failures = 0;
             }
+
+            // Always refresh balance and timestamp
+            current_health.last_known_balance = actual_balance;
+            current_health.last_check_timestamp = current_time;
+
+            env.storage().instance().set(&health_key, &current_health);
         }
 
         Ok(unhealthy_strategies)
@@ -1829,11 +1850,22 @@ impl VolatilityShield {
         let health_key = DataKey::StrategyHealth(strategy.clone());
         let current_time = env.ledger().timestamp();
 
-        // Update health to unhealthy
+        // Update health to unhealthy, preserving the existing counter
+        let existing: StrategyHealth = env
+            .storage()
+            .instance()
+            .get(&health_key)
+            .unwrap_or(StrategyHealth {
+                last_known_balance: 0,
+                last_check_timestamp: current_time,
+                is_healthy: true,
+                consecutive_failures: 0,
+            });
         let updated_health = StrategyHealth {
-            last_known_balance: 0, // Will be updated on next health check
+            last_known_balance: existing.last_known_balance,
             last_check_timestamp: current_time,
             is_healthy: false,
+            consecutive_failures: existing.consecutive_failures,
         };
 
         env.storage().instance().set(&health_key, &updated_health);
@@ -1904,6 +1936,30 @@ impl VolatilityShield {
         env.storage()
             .instance()
             .get(&DataKey::StrategyHealth(strategy))
+    }
+
+    /// Set the number of consecutive failed balance checks before a strategy is
+    /// auto-flagged as unhealthy.  Defaults to 3 when not configured.
+    /// Only the admin can call this.
+    pub fn set_max_consecutive_failures(env: Env, threshold: u32) -> Result<(), Error> {
+        Self::require_admin(&env);
+        if threshold == 0 {
+            return Err(Error::NegativeAmount);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::MaxConsecutiveFailures, &threshold);
+        env.events()
+            .publish((symbol_short!("MaxFail"),), threshold);
+        Ok(())
+    }
+
+    /// Return the currently configured consecutive-failure threshold (default: 3).
+    pub fn get_max_consecutive_failures(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::MaxConsecutiveFailures)
+            .unwrap_or(3)
     }
 
     /// Calculate annualized percentage yield (APY) for a strategy.

--- a/smartcontract/contracts/volatility_shield/src/test.rs
+++ b/smartcontract/contracts/volatility_shield/src/test.rs
@@ -695,6 +695,193 @@ mod strategy_health_tests {
         let result = client.try_check_strategy_health();
         assert_eq!(result, Err(Ok(Error::NoStrategies)));
     }
+
+    // ── Issue #334: consecutive-failure strike counter ────────────────────
+
+    /// AC-1: Three consecutive unhealthy checks auto-flag the strategy.
+    #[test]
+    fn test_three_consecutive_failures_auto_flags() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, VolatilityShield);
+        let client = VolatilityShieldClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let asset = Address::generate(&env);
+        let oracle = Address::generate(&env);
+        let treasury = Address::generate(&env);
+        let guardians = soroban_sdk::vec![&env, admin.clone()];
+        client.init(&admin, &asset, &oracle, &treasury, &0u32, &guardians, &1u32);
+
+        let (mock_strategy_id, mock_client) = create_mock_strategy(&env);
+        client.propose_action(&admin, &ActionType::AddStrategy(mock_strategy_id.clone()));
+
+        // Allocate 100 % of vault assets to the strategy
+        let mut allocations: Map<Address, i128> = Map::new(&env);
+        allocations.set(mock_strategy_id.clone(), 10000);
+        env.ledger().set_timestamp(1000);
+        client.set_oracle_data(&allocations, &env.ledger().timestamp());
+
+        // Vault thinks it has 1000 assets; strategy holds 800 (>10 % deviation → unhealthy)
+        client.set_total_assets(&1000);
+        mock_client.deposit(&800);
+
+        // Run health-check 3 times
+        for i in 1_u32..=3 {
+            env.ledger().set_timestamp(1000 + i as u64 * 100);
+            let unhealthy = client.check_strategy_health();
+            assert_eq!(
+                unhealthy.get(0).unwrap(),
+                mock_strategy_id,
+                "strategy should appear unhealthy on check {i}"
+            );
+        }
+
+        // After 3 failures the strategy must be auto-flagged
+        let health = client.get_strategy_health(&mock_strategy_id).unwrap();
+        assert!(!health.is_healthy, "strategy should be auto-flagged after 3 failures");
+        assert_eq!(health.consecutive_failures, 3);
+    }
+
+    /// AC-2: A single successful check resets the consecutive-failure counter.
+    #[test]
+    fn test_single_recovery_resets_counter() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, VolatilityShield);
+        let client = VolatilityShieldClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let asset = Address::generate(&env);
+        let oracle = Address::generate(&env);
+        let treasury = Address::generate(&env);
+        let guardians = soroban_sdk::vec![&env, admin.clone()];
+        client.init(&admin, &asset, &oracle, &treasury, &0u32, &guardians, &1u32);
+
+        let (mock_strategy_id, mock_client) = create_mock_strategy(&env);
+        client.propose_action(&admin, &ActionType::AddStrategy(mock_strategy_id.clone()));
+
+        let mut allocations: Map<Address, i128> = Map::new(&env);
+        allocations.set(mock_strategy_id.clone(), 10000);
+        env.ledger().set_timestamp(1000);
+        client.set_oracle_data(&allocations, &env.ledger().timestamp());
+        client.set_total_assets(&1000);
+
+        // Two failures (strategy is under-funded)
+        mock_client.deposit(&800);
+        for i in 1_u32..=2 {
+            env.ledger().set_timestamp(1000 + i as u64 * 100);
+            client.check_strategy_health();
+        }
+        let health = client.get_strategy_health(&mock_strategy_id).unwrap();
+        assert_eq!(health.consecutive_failures, 2, "should have 2 failures before recovery");
+
+        // Recovery: bring strategy balance in line with expected
+        mock_client.deposit(&200); // now 1000, within 10 % of 1000
+        env.ledger().set_timestamp(1400);
+        client.check_strategy_health();
+
+        let health = client.get_strategy_health(&mock_strategy_id).unwrap();
+        assert_eq!(
+            health.consecutive_failures, 0,
+            "counter must reset to 0 after a successful check"
+        );
+    }
+
+    /// AC-3: Admin can configure a custom failure threshold.
+    #[test]
+    fn test_custom_threshold_configurable_by_admin() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, VolatilityShield);
+        let client = VolatilityShieldClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let asset = Address::generate(&env);
+        let oracle = Address::generate(&env);
+        let treasury = Address::generate(&env);
+        let guardians = soroban_sdk::vec![&env, admin.clone()];
+        client.init(&admin, &asset, &oracle, &treasury, &0u32, &guardians, &1u32);
+
+        // Default threshold is 3
+        assert_eq!(client.get_max_consecutive_failures(), 3);
+
+        // Admin bumps threshold to 5
+        client.set_max_consecutive_failures(&5u32);
+        assert_eq!(client.get_max_consecutive_failures(), 5);
+
+        let (mock_strategy_id, mock_client) = create_mock_strategy(&env);
+        client.propose_action(&admin, &ActionType::AddStrategy(mock_strategy_id.clone()));
+
+        let mut allocations: Map<Address, i128> = Map::new(&env);
+        allocations.set(mock_strategy_id.clone(), 10000);
+        env.ledger().set_timestamp(1000);
+        client.set_oracle_data(&allocations, &env.ledger().timestamp());
+        client.set_total_assets(&1000);
+        mock_client.deposit(&800); // consistently 20 % under
+
+        // 4 failures should NOT yet auto-flag (threshold = 5)
+        for i in 1_u32..=4 {
+            env.ledger().set_timestamp(1000 + i as u64 * 100);
+            client.check_strategy_health();
+        }
+        let health = client.get_strategy_health(&mock_strategy_id).unwrap();
+        assert!(health.is_healthy, "should still be healthy after 4 failures when threshold is 5");
+        assert_eq!(health.consecutive_failures, 4);
+
+        // 5th failure → auto-flagged
+        env.ledger().set_timestamp(1500);
+        client.check_strategy_health();
+        let health = client.get_strategy_health(&mock_strategy_id).unwrap();
+        assert!(!health.is_healthy, "should be auto-flagged on 5th failure");
+        assert_eq!(health.consecutive_failures, 5);
+    }
+
+    /// Default threshold stays 3 when admin never calls set_max_consecutive_failures.
+    #[test]
+    fn test_default_threshold_is_three() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, VolatilityShield);
+        let client = VolatilityShieldClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let asset = Address::generate(&env);
+        let oracle = Address::generate(&env);
+        let treasury = Address::generate(&env);
+        let guardians = soroban_sdk::vec![&env, admin.clone()];
+        client.init(&admin, &asset, &oracle, &treasury, &0u32, &guardians, &1u32);
+
+        assert_eq!(client.get_max_consecutive_failures(), 3);
+    }
+
+    /// New strategy starts with consecutive_failures = 0.
+    #[test]
+    fn test_new_strategy_starts_with_zero_failures() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, VolatilityShield);
+        let client = VolatilityShieldClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let asset = Address::generate(&env);
+        let oracle = Address::generate(&env);
+        let treasury = Address::generate(&env);
+        let guardians = soroban_sdk::vec![&env, admin.clone()];
+        client.init(&admin, &asset, &oracle, &treasury, &0u32, &guardians, &1u32);
+
+        let (mock_strategy_id, _) = create_mock_strategy(&env);
+        client.propose_action(&admin, &ActionType::AddStrategy(mock_strategy_id.clone()));
+
+        let health = client.get_strategy_health(&mock_strategy_id).unwrap();
+        assert_eq!(health.consecutive_failures, 0);
+        assert!(health.is_healthy);
+    }
 }
 
 // ── Timelock Tests ─────────────────────────


### PR DESCRIPTION
## Summary
Implements the consecutive-failure strike counter for `StrategyHealth` as specified in Issue #334 / SC-26.

## Changes
- `lib.rs`: added `consecutive_failures: u32` to `StrategyHealth`; added `DataKey::MaxConsecutiveFailures`; updated `check_strategy_health()` to increment/reset the counter and auto-flag at threshold; updated `internal_add_strategy` and `flag_strategy` to initialise/preserve the field; added `set_max_consecutive_failures()` and `get_max_consecutive_failures()`
- `test.rs`: 5 new tests inside `strategy_health_tests` covering all 3 acceptance criteria

## Acceptance criteria
- [x] Intermittently failing strategies are eventually auto-flagged after N consecutive failures
- [x] A single recovery resets the counter to 0
- [x] Custom threshold is configurable by admin via `DataKey::MaxConsecutiveFailures`

Closes #334