### PR TITLE
Feat/fe 64 inactivity warning modal

### DIFF
--- a/frontend/app/components/InactivityWarningModal.tsx
+++ b/frontend/app/components/InactivityWarningModal.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Modal } from "@/components/ui/modal";
+
+interface InactivityWarningModalProps {
+  isOpen: boolean;
+  warningSeconds: number;
+  onStayConnected: () => void;
+  onDisconnectNow: () => void;
+  onClose: () => void;
+}
+
+function formatSeconds(totalSeconds: number): string {
+  const clamped = Math.max(0, Math.floor(totalSeconds));
+  const minutes = Math.floor(clamped / 60);
+  const seconds = clamped % 60;
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}
+
+export function InactivityWarningModal({
+  isOpen,
+  warningSeconds,
+  onStayConnected,
+  onDisconnectNow,
+  onClose,
+}: InactivityWarningModalProps) {
+  const [secondsRemaining, setSecondsRemaining] = useState(warningSeconds);
+  const endAtRef = useRef<number | null>(null);
+
+  const animationKey = useMemo(() => {
+    if (!isOpen) return "closed";
+    return `${warningSeconds}-${Date.now()}`;
+  }, [isOpen, warningSeconds]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const now = Date.now();
+    endAtRef.current = now + warningSeconds * 1000;
+    setSecondsRemaining(warningSeconds);
+
+    const id = window.setInterval(() => {
+      const endAt = endAtRef.current;
+      if (!endAt) return;
+      const msLeft = endAt - Date.now();
+      const nextSeconds = Math.ceil(msLeft / 1000);
+      setSecondsRemaining(nextSeconds);
+      if (msLeft <= 0) {
+        window.clearInterval(id);
+      }
+    }, 250);
+
+    return () => {
+      window.clearInterval(id);
+    };
+  }, [isOpen, warningSeconds]);
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="You’re about to be disconnected" size="sm">
+      <div className="space-y-4">
+        <p className="text-sm text-muted-foreground">
+          For your security, we’ll disconnect your wallet due to inactivity.
+        </p>
+
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-medium">Time remaining</span>
+            <span className="text-sm font-mono">{formatSeconds(secondsRemaining)}</span>
+          </div>
+          <div className="h-2 w-full overflow-hidden rounded bg-secondary">
+            <div
+              key={animationKey}
+              className="h-full bg-primary"
+              style={{
+                animationName: "shrink",
+                animationDuration: `${warningSeconds}s`,
+                animationTimingFunction: "linear",
+                animationFillMode: "forwards",
+              }}
+            />
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+          <button
+            onClick={() => {
+              onStayConnected();
+              onClose();
+            }}
+            className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-indigo-500 active:bg-indigo-700"
+          >
+            Stay Connected
+          </button>
+          <button
+            onClick={() => {
+              onDisconnectNow();
+              onClose();
+            }}
+            className="rounded-lg border border-red-500/30 bg-red-950/30 px-4 py-2 text-sm text-red-400 transition-colors hover:bg-red-900/40"
+          >
+            Disconnect Now
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/app/context/FreighterContext.tsx
+++ b/frontend/app/context/FreighterContext.tsx
@@ -9,6 +9,7 @@ import {
   type ReactNode,
 } from "react";
 import { useInactivityLogout } from "../../hooks/use-inactivity-logout";
+import { InactivityWarningModal } from "../components/InactivityWarningModal";
 
 /* ── Freighter API v2 ─────────────────────────────────── */
 import {
@@ -55,6 +56,7 @@ const FreighterContext = createContext<FreighterContextValue | undefined>(
 /* ── Provider ────────────────────────────────────────── */
 export function FreighterProvider({ children }: { children: ReactNode }) {
   const [state, setState] = useState<FreighterState>(initialState);
+  const [isWarningOpen, setIsWarningOpen] = useState(false);
 
   /**
    * Check if Freighter is installed and whether it has previously
@@ -156,17 +158,33 @@ export function FreighterProvider({ children }: { children: ReactNode }) {
       isLoading: false,
       error: null,
     });
+    setIsWarningOpen(false);
   }, []);
 
-  useInactivityLogout({
+  const { resetInactivityTimer } = useInactivityLogout({
     timeout: 15 * 60 * 1000,
     onLogout: disconnect,
-    onWarning: () => console.warn("Session expiring in 60 seconds..."),
+    onWarning: () => {
+      setIsWarningOpen(true);
+    },
   });
 
   return (
     <FreighterContext.Provider value={{ ...state, connect, disconnect }}>
       {children}
+      <InactivityWarningModal
+        isOpen={isWarningOpen && state.isConnected}
+        warningSeconds={60}
+        onStayConnected={() => {
+          resetInactivityTimer();
+        }}
+        onDisconnectNow={() => {
+          disconnect();
+        }}
+        onClose={() => {
+          setIsWarningOpen(false);
+        }}
+      />
     </FreighterContext.Provider>
   );
 }

--- a/frontend/hooks/use-inactivity-logout.spec.ts
+++ b/frontend/hooks/use-inactivity-logout.spec.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { inactivityLogoutEvents, useInactivityLogout } from "./use-inactivity-logout";
+
+describe("useInactivityLogout warning threshold", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("emits warningThreshold exactly 60 seconds before timeout", () => {
+    vi.useFakeTimers();
+
+    const timeoutMs = 5 * 60 * 1000;
+    const onLogout = vi.fn();
+
+    let warningEvents = 0;
+    const handler = () => {
+      warningEvents += 1;
+    };
+
+    inactivityLogoutEvents.addEventListener("warningThreshold", handler);
+
+    const { unmount } = renderHook(() =>
+      useInactivityLogout({
+        timeout: timeoutMs,
+        onLogout,
+      })
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(timeoutMs - 60_000 - 1);
+    });
+
+    expect(warningEvents).toBe(0);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+
+    expect(warningEvents).toBe(1);
+
+    unmount();
+    inactivityLogoutEvents.removeEventListener("warningThreshold", handler);
+  });
+});

--- a/frontend/hooks/use-inactivity-logout.ts
+++ b/frontend/hooks/use-inactivity-logout.ts
@@ -5,6 +5,8 @@ import { useEffect, useRef, useCallback } from "react";
 const DEFAULT_TIMEOUT = 15 * 60 * 1000; // 15 minutes
 const WARNING_THRESHOLD = 60 * 1000; // 60 seconds before logout
 
+export const inactivityLogoutEvents = new EventTarget();
+
 interface InactivityOptions {
   timeout?: number;
   onLogout: () => void;
@@ -24,8 +26,16 @@ export function useInactivityLogout({
     if (warningTimerRef.current) clearTimeout(warningTimerRef.current);
 
     warningTimerRef.current = setTimeout(() => {
+      inactivityLogoutEvents.dispatchEvent(
+        new CustomEvent("warningThreshold", {
+          detail: {
+            warningThresholdMs: WARNING_THRESHOLD,
+            timeoutMs: timeout,
+          },
+        })
+      );
       onWarning?.();
-    }, timeout - WARNING_THRESHOLD);
+    }, Math.max(0, timeout - WARNING_THRESHOLD));
 
     timerRef.current = setTimeout(() => {
       onLogout();
@@ -53,4 +63,8 @@ export function useInactivityLogout({
       if (warningTimerRef.current) clearTimeout(warningTimerRef.current);
     };
   }, [resetTimers]);
+
+  return {
+    resetInactivityTimer: resetTimers,
+  };
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test:unit": "vitest run",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui"
   },
@@ -35,15 +36,19 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
     "@types/node": "^20.19.34",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "autoprefixer": "^10.4.0",
     "eslint": "^10.0.1",
     "eslint-config-next": "16.1.1",
+    "jsdom": "^25.0.1",
     "postcss": "^8.4.0",
     "tailwindcss": "^3.4.0",
     "tailwindcss-animate": "^1.0.7",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "vitest": "^2.1.9"
   }
 }

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    setupFiles: ["./vitest.setup.ts"],
+    globals: true,
+    restoreMocks: true,
+    clearMocks: true,
+  },
+});

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";


### PR DESCRIPTION
## Summary
- Adds an inactivity warning modal that appears 60 seconds before the wallet auto-disconnect triggers.
- Modal includes a live countdown timer and an animated countdown bar.
- Users can extend the session ("Stay Connected") or disconnect immediately ("Disconnect Now").
- Adds a unit test to verify the warning event fires at `timeout - 60s`.

## Notes
- Warning is triggered exactly 60 seconds before timeout via a `warningThreshold` CustomEvent.
- Countdown accuracy is based on an `endAt` timestamp and updates multiple times per second.

Closes #312

@bbkenny PR is ready for review!