### PR TITLE
Feat/fe 62 apy chart real data

### DIFF
--- a/frontend/app/vault/page.tsx
+++ b/frontend/app/vault/page.tsx
@@ -36,6 +36,7 @@ export default function VaultPage() {
   const [estimatedFee, setEstimatedFee] = useState<string | null>(null);
   const [estimatingFee, setEstimatingFee] = useState(false);
   const [chartLoading, setChartLoading] = useState(false);
+  const [chartError, setChartError] = useState<string | null>(null);
   const [metrics, setMetrics] = useState<VaultMetrics | null>(null);
   const [selectedTimeframe, setSelectedTimeframe] = useState<Timeframe>('1M');
   const [chartData, setChartData] = useState<DataPoint[]>([]);
@@ -64,6 +65,7 @@ export default function VaultPage() {
   useEffect(() => {
     const loadChartData = async () => {
       setChartLoading(true);
+      setChartError(null);
       try {
         const contractId = getVolatilityShieldAddress(network);
         const data = await fetchApyData(selectedTimeframe, contractId, network);
@@ -71,6 +73,7 @@ export default function VaultPage() {
       } catch (error) {
         console.error('Failed to load chart data:', error);
         setChartData([]);
+        setChartError('Failed to load APY history');
       } finally {
         setChartLoading(false);
       }
@@ -471,7 +474,7 @@ export default function VaultPage() {
               loading={chartLoading}
             />
           </div>
-          <VaultAPYChart data={chartData} loading={chartLoading} />
+          <VaultAPYChart data={chartData} loading={chartLoading} error={chartError} />
         </div>
       )}
 

--- a/frontend/components/TimeframeFilter.tsx
+++ b/frontend/components/TimeframeFilter.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { Button } from './ui/button';
 import { cn } from '@/lib/utils';
 
-export type Timeframe = '1D' | '1W' | '1M' | '1Y';
+export type Timeframe = '1D' | '1W' | '1M' | '3M' | '1Y';
 
 interface TimeframeFilterProps {
   selectedTimeframe: Timeframe;
@@ -16,6 +16,7 @@ const timeframes: { value: Timeframe; label: string }[] = [
   { value: '1D', label: '1D' },
   { value: '1W', label: '1W' },
   { value: '1M', label: '1M' },
+  { value: '3M', label: '3M' },
   { value: '1Y', label: '1Y' },
 ];
 

--- a/frontend/components/VaultAPYChart.tsx
+++ b/frontend/components/VaultAPYChart.tsx
@@ -19,9 +19,10 @@ type DataPoint = {
 interface VaultAPYChartProps {
     data: DataPoint[];
     loading?: boolean;
+    error?: string | null;
 }
 
-export default function VaultAPYChart({ data, loading = false }: VaultAPYChartProps) {
+export default function VaultAPYChart({ data, loading = false, error = null }: VaultAPYChartProps) {
     if (loading) {
         return (
             <div className="w-full h-72 flex items-center justify-center">
@@ -29,6 +30,14 @@ export default function VaultAPYChart({ data, loading = false }: VaultAPYChartPr
                     <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
                     <p className="text-sm text-muted-foreground">Loading chart data...</p>
                 </div>
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <div className="flex h-64 items-center justify-center rounded-lg border border-dashed bg-card/50 text-muted-foreground">
+                Failed to load APY history
             </div>
         );
     }

--- a/frontend/lib/chart-data.ts
+++ b/frontend/lib/chart-data.ts
@@ -54,6 +54,9 @@ function getDateRange(timeframe: Timeframe): { from: Date; to: Date } {
     case '1M':
       from.setDate(to.getDate() - 30);
       break;
+    case '3M':
+      from.setDate(to.getDate() - 90);
+      break;
     case '1Y':
       from.setFullYear(to.getFullYear() - 1);
       break;

--- a/frontend/lib/stellar.ts
+++ b/frontend/lib/stellar.ts
@@ -8,6 +8,7 @@ import {
   xdr,
   Contract,
   rpc,
+  scValToNative,
 } from "@stellar/stellar-sdk";
 
 export enum NetworkType {
@@ -20,6 +21,12 @@ const RPC_URLS: Record<NetworkType, string> = {
   [NetworkType.MAINNET]: "https://horizon.stellar.org",
   [NetworkType.TESTNET]: "https://horizon-testnet.stellar.org",
   [NetworkType.FUTURENET]: "https://horizon-futurenet.stellar.org",
+};
+
+const SOROBAN_RPC_URLS: Record<NetworkType, string> = {
+  [NetworkType.MAINNET]: "https://rpc.mainnet.stellar.org",
+  [NetworkType.TESTNET]: "https://rpc.testnet.stellar.org",
+  [NetworkType.FUTURENET]: "https://rpc-futurenet.stellar.org",
 };
 
 export interface VaultMetrics {
@@ -390,59 +397,141 @@ export async function fetchHistoricalSharePrice(
   toDate?: Date
 ): Promise<HistoricalSharePrice[]> {
   try {
-    const horizonUrl = RPC_URLS[network];
-    const server = new Horizon.Server(horizonUrl);
-
     const endDate = toDate || new Date();
     const startDate = fromDate || new Date(endDate.getTime() - 30 * 24 * 60 * 60 * 1000);
+    const rpcUrl = SOROBAN_RPC_URLS[network];
+    const server = new rpc.Server(rpcUrl);
 
-    // Format dates for Horizon API (ISO 8601)
-    const startISO = startDate.toISOString();
-    const endISO = endDate.toISOString();
+    const latestLedger = await server.getLatestLedger();
 
-    // Query contract events - look for state changes related to share price
-    // This is a simplified implementation - real implementation would:
-    // 1. Query all Deposit/Withdraw events from the contract
-    // 2. Track cumulative totalAssets and totalShares
-    // 3. Calculate share price at each point: totalAssets / totalShares
-    // 4. Group by time period (day/week/month depending on timeframe)
+    const nowMs = Date.now();
+    const avgLedgerCloseMs = 5_000;
+    const ledgersAgo = Math.ceil((nowMs - startDate.getTime()) / avgLedgerCloseMs);
+    const maxLedgerRange = 200_000;
 
-    // For now, return empty array - in production this would fetch from Mercury indexer or similar
-    // The frontend can then fall back to mock data or show "No history available"
+    const estimatedStartLedger = Math.max(1, latestLedger.sequence - ledgersAgo);
+    const earliestAllowedLedger = Math.max(1, latestLedger.sequence - maxLedgerRange);
+    let startLedger = Math.max(estimatedStartLedger, earliestAllowedLedger);
 
-    const now = new Date();
-    const dataPoints: HistoricalSharePrice[] = [];
+    const rawPoints: Array<{ timestamp: number; price: number }> = [];
 
-    // Generate synthetic data points for demonstration
-    // In production, this would come from Mercury indexer or Horizon event queries
-    let currentDate = new Date(startDate);
-    let sharePrice = 1.0;
+    while (startLedger <= latestLedger.sequence) {
+      const resp = await server.getEvents({
+        startLedger,
+        filters: [
+          {
+            type: "contract",
+            contractIds: [contractId],
+          },
+        ],
+      } as any);
 
-    while (currentDate <= endDate) {
-      const timestamp = currentDate.getTime();
-      const dateStr = currentDate.toLocaleDateString("en-US", {
-        month: "short",
-        day: "numeric",
-      });
+      const events = resp?.events || [];
+      if (events.length === 0) {
+        break;
+      }
 
-      // Simulate slight APY (2-6% annual yield)
-      const daysSinceStart =
-        (currentDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24);
-      const apyRate = 0.04; // 4% APY
-      const dailyRate = apyRate / 365;
-      sharePrice = 1.0 * Math.pow(1 + dailyRate, daysSinceStart);
+      let maxSeenLedger = startLedger;
 
-      dataPoints.push({
-        timestamp,
-        price: parseFloat(sharePrice.toFixed(7)),
-        date: dateStr,
-      });
+      for (const e of events) {
+        maxSeenLedger = Math.max(maxSeenLedger, Number(e.ledger));
 
-      // Move to next day
-      currentDate.setDate(currentDate.getDate() + 1);
+        const closedAt = e.ledgerClosedAt ? Date.parse(e.ledgerClosedAt) : NaN;
+        const timestamp = Number.isFinite(closedAt) ? closedAt : Date.now();
+        if (timestamp < startDate.getTime() || timestamp > endDate.getTime()) {
+          continue;
+        }
+
+        let eventName: string | null = null;
+        try {
+          eventName = String(scValToNative(e.topic?.[0]));
+        } catch {
+          eventName = null;
+        }
+
+        if (eventName !== "Deposit" && eventName !== "Withdraw") {
+          continue;
+        }
+
+        let nativeValue: any;
+        try {
+          nativeValue = scValToNative(e.value);
+        } catch {
+          continue;
+        }
+
+        const tuple = Array.isArray(nativeValue) ? nativeValue : null;
+        const sharePriceScaled =
+          eventName === "Deposit" ? tuple?.[2] : tuple?.[1];
+
+        if (sharePriceScaled === undefined || sharePriceScaled === null) {
+          continue;
+        }
+
+        let sharePriceBigInt: bigint | null = null;
+        try {
+          if (typeof sharePriceScaled === "bigint") {
+            sharePriceBigInt = sharePriceScaled;
+          } else if (typeof sharePriceScaled === "number") {
+            sharePriceBigInt = BigInt(Math.trunc(sharePriceScaled));
+          } else if (typeof sharePriceScaled === "string") {
+            sharePriceBigInt = BigInt(sharePriceScaled);
+          }
+        } catch {
+          sharePriceBigInt = null;
+        }
+
+        if (sharePriceBigInt === null) {
+          continue;
+        }
+
+        const price = Number(sharePriceBigInt) / 1e9;
+        if (!Number.isFinite(price) || price <= 0) {
+          continue;
+        }
+
+        rawPoints.push({ timestamp, price });
+      }
+
+      if (maxSeenLedger <= startLedger) {
+        startLedger = startLedger + 1;
+      } else {
+        startLedger = maxSeenLedger + 1;
+      }
     }
 
-    return dataPoints;
+    if (rawPoints.length === 0) {
+      return [];
+    }
+
+    rawPoints.sort((a, b) => a.timestamp - b.timestamp);
+
+    const dailyLastPoint = new Map<string, { timestamp: number; price: number }>();
+    for (const p of rawPoints) {
+      const d = new Date(p.timestamp);
+      const key = `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}-${String(
+        d.getUTCDate()
+      ).padStart(2, "0")}`;
+      const existing = dailyLastPoint.get(key);
+      if (!existing || existing.timestamp <= p.timestamp) {
+        dailyLastPoint.set(key, p);
+      }
+    }
+
+    return Array.from(dailyLastPoint.values())
+      .sort((a, b) => a.timestamp - b.timestamp)
+      .map((p) => {
+        const dateStr = new Date(p.timestamp).toLocaleDateString("en-US", {
+          month: "short",
+          day: "numeric",
+        });
+
+        return {
+          timestamp: p.timestamp,
+          price: parseFloat(p.price.toFixed(9)),
+          date: dateStr,
+        };
+      });
   } catch (error) {
     console.error("Failed to fetch historical share price:", error);
     return [];

--- a/frontend/tests/apy-chart.spec.ts
+++ b/frontend/tests/apy-chart.spec.ts
@@ -1,0 +1,192 @@
+import { test, expect } from '@playwright/test';
+
+async function injectMockFreighter(page: import('@playwright/test').Page) {
+  await page.addInitScript(() => {
+    const mockFreighter = {
+      isConnected: () => Promise.resolve(true),
+      getPublicKey: () =>
+        Promise.resolve('GBXFQY665K3S3SZESTSY3A4Y5Z6K2O3B4C5D6E7F8G9H0I1J2K3L4M5N'),
+      isAllowed: () => Promise.resolve(true),
+      setAllowed: () => Promise.resolve(true),
+      getNetwork: () => Promise.resolve('TESTNET'),
+      requestAccess: () =>
+        Promise.resolve('GBXFQY665K3S3SZESTSY3A4Y5Z6K2O3B4C5D6E7F8G9H0I1J2K3L4M5N'),
+      signTransaction: (xdr: string) => Promise.resolve(xdr),
+    };
+    (window as any).freighter = mockFreighter;
+  });
+}
+
+test.describe('APY chart historical share price feed', () => {
+  test('renders empty state when no history exists (no mock fallback)', async ({ page }) => {
+    await injectMockFreighter(page);
+
+    let latestLedgerCalls = 0;
+    let eventsCalls = 0;
+
+    await page.route('**/*', async (route) => {
+      const request = route.request();
+      if (request.method() === 'POST' && request.url().includes('rpc')) {
+        const postData = request.postDataJSON?.();
+
+        if (postData?.method === 'getLatestLedger') {
+          latestLedgerCalls++;
+          await route.fulfill({
+            json: {
+              jsonrpc: '2.0',
+              id: postData.id,
+              result: { id: 'l', protocolVersion: 20, sequence: 200500 },
+            },
+          });
+          return;
+        }
+
+        if (postData?.method === 'getEvents') {
+          eventsCalls++;
+          await route.fulfill({
+            json: {
+              jsonrpc: '2.0',
+              id: postData.id,
+              result: {
+                latestLedger: 200500,
+                events: [],
+              },
+            },
+          });
+          return;
+        }
+      }
+
+      await route.fallback();
+    });
+
+    await page.goto('/vault');
+
+    const connectBtn = page.locator('button:has-text("Connect Wallet")');
+    if (await connectBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
+      await connectBtn.click();
+    }
+
+    await expect(page.locator('h2:has-text("APY History")')).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('text=No APY data available')).toBeVisible({ timeout: 15000 });
+
+    expect(latestLedgerCalls).toBeGreaterThan(0);
+    expect(eventsCalls).toBeGreaterThan(0);
+  });
+
+  test('timeframe filter changes query startLedger (range limiting)', async ({ page }) => {
+    await injectMockFreighter(page);
+
+    const observedStartLedgers: number[] = [];
+    let getEventsCallIndex = 0;
+
+    await page.route('**/*', async (route) => {
+      const request = route.request();
+      if (request.method() === 'POST' && request.url().includes('rpc')) {
+        const postData = request.postDataJSON?.();
+
+        if (postData?.method === 'getLatestLedger') {
+          await route.fulfill({
+            json: {
+              jsonrpc: '2.0',
+              id: postData.id,
+              result: { id: 'l', protocolVersion: 20, sequence: 200500 },
+            },
+          });
+          return;
+        }
+
+        if (postData?.method === 'getEvents') {
+          const startLedger = postData?.params?.[0]?.startLedger;
+          if (typeof startLedger === 'number') {
+            observedStartLedgers.push(startLedger);
+          }
+
+          // First getEvents call returns one Deposit event, next returns empty to end loop.
+          getEventsCallIndex++;
+          if (getEventsCallIndex === 1) {
+            await route.fulfill({
+              json: {
+                jsonrpc: '2.0',
+                id: postData.id,
+                result: {
+                  latestLedger: 200500,
+                  events: [
+                    {
+                      type: 'contract',
+                      ledger: 200000,
+                      ledgerClosedAt: new Date().toISOString(),
+                      contractId: 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC',
+                      id: '0000-01',
+                      pagingToken: '0000-01',
+                      topic: [{ _type: 'scvSymbol', _value: 'Deposit' }],
+                      value: {
+                        _type: 'scvVec',
+                        _value: [
+                          { _type: 'scvU32', _value: 0 },
+                          { _type: 'scvI128', _value: '10000000' },
+                          { _type: 'scvI128', _value: '1000000000' },
+                          { _type: 'scvI128', _value: '1000000000' },
+                          { _type: 'scvI128', _value: '1000000000' },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              },
+            });
+            return;
+          }
+
+          await route.fulfill({
+            json: {
+              jsonrpc: '2.0',
+              id: postData.id,
+              result: {
+                latestLedger: 200500,
+                events: [],
+              },
+            },
+          });
+          return;
+        }
+      }
+
+      await route.fallback();
+    });
+
+    await page.goto('/vault');
+
+    const connectBtn = page.locator('button:has-text("Connect Wallet")');
+    if (await connectBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
+      await connectBtn.click();
+    }
+
+    await expect(page.locator('h2:has-text("APY History")')).toBeVisible({ timeout: 15000 });
+
+    // Change timeframe to 1D, then 1Y, and verify startLedger shifts.
+    // We wait for a getEvents request each time (the chart data effect re-runs).
+    const firstReq = page.waitForRequest(
+      (req) => req.method() === 'POST' && req.url().includes('rpc') && req.postDataJSON()?.method === 'getEvents',
+      { timeout: 30000 }
+    );
+    await page.locator('button:has-text("1D")').click();
+    await firstReq;
+
+    const secondReq = page.waitForRequest(
+      (req) => req.method() === 'POST' && req.url().includes('rpc') && req.postDataJSON()?.method === 'getEvents',
+      { timeout: 30000 }
+    );
+    await page.locator('button:has-text("1Y")').click();
+    await secondReq;
+
+    // We expect at least two observed startLedgers across calls.
+    expect(observedStartLedgers.length).toBeGreaterThan(1);
+
+    const maxStart = Math.max(...observedStartLedgers);
+    const minStart = Math.min(...observedStartLedgers);
+
+    // Shorter timeframe => higher startLedger (closer to latest ledger).
+    expect(maxStart).toBeGreaterThan(minStart);
+  });
+});


### PR DESCRIPTION
## Summary
- Replaced mock APY chart feed with real historical share price snapshots derived from Soroban contract events (Deposit/Withdraw).
- Added 3M timeframe support and ensured timeframe selection limits the event query range.
- Added loading / empty / error handling for APY chart (no mock fallback on empty history).
- Added Playwright integration-style tests with mocked Soroban RPC responses.

## Testing
- Added [frontend/tests/apy-chart.spec.ts](cci:7://file:///c:/Users/Oluwaseun/Documents/XHedge/frontend/tests/apy-chart.spec.ts:0:0-0:0) (mocks `getLatestLedger` + `getEvents`).

Closes #310

@bbkenny PR is ready for review!