### PR TITLE
Add governance pruning, listing, and vault history reads

### DIFF
--- a/smartcontract/contracts/volatility_shield/src/lib.rs
+++ b/smartcontract/contracts/volatility_shield/src/lib.rs
@@ -4,6 +4,9 @@ use soroban_sdk::{
     Vec,
 };
 
+const DEFAULT_PROPOSAL_TTL_LEDGERS: u32 = 518_400;
+const SHARE_PRICE_HISTORY_CAP: u32 = 365;
+
 // ─────────────────────────────────────────────
 // Error types
 // ─────────────────────────────────────────────
@@ -65,7 +68,9 @@ pub enum DataKey {
     Guardians,
     Threshold,
     Proposals,
+    ProposalIds,
     NextProposalId,
+    ProposalTtlLedgers,
     WithdrawQueueThreshold,
     PendingWithdrawals,
     StrategyHealth(Address),
@@ -83,6 +88,8 @@ pub enum DataKey {
     AllowlistMode,
     Blocklist,
     Allowlist,
+    PauseHistory,
+    SharePriceHistory,
 }
 
 // ─────────────────────────────────────────────
@@ -112,6 +119,7 @@ pub struct Proposal {
     pub action: ActionType,
     pub approvals: Vec<Address>,
     pub executed: bool,
+    pub executed_ledger: u32,
     pub proposed_at: u64,
 }
 
@@ -274,6 +282,8 @@ impl VolatilityShield {
             return Err(Error::Unauthorized);
         }
 
+        Self::prune_old_proposals_internal(&env);
+
         let id = env
             .storage()
             .instance()
@@ -290,6 +300,7 @@ impl VolatilityShield {
             action: action.clone(),
             approvals: soroban_sdk::vec![&env, proposer],
             executed: false,
+            executed_ledger: 0,
             proposed_at,
         };
 
@@ -304,13 +315,14 @@ impl VolatilityShield {
             .unwrap_or(1);
         if threshold <= 1 {
             // Try to execute, but if timelock hasn't elapsed, the proposal will remain unexecuted
-            let res = Self::execute_action(&env, &action, proposed_at);
+            let res = Self::execute_action(&env, &proposer, &action, proposed_at);
             if let Err(e) = res {
                 if e != Error::TimelockNotElapsed {
                     return Err(e);
                 }
             } else {
                 proposal.executed = true;
+                proposal.executed_ledger = env.ledger().sequence();
             }
         }
 
@@ -323,6 +335,15 @@ impl VolatilityShield {
         env.storage()
             .instance()
             .set(&DataKey::Proposals, &proposals);
+        let mut proposal_ids: Vec<u64> = env
+            .storage()
+            .instance()
+            .get(&DataKey::ProposalIds)
+            .unwrap_or(Vec::new(&env));
+        proposal_ids.push_back(id);
+        env.storage()
+            .instance()
+            .set(&DataKey::ProposalIds, &proposal_ids);
 
         Ok(id)
     }
@@ -342,6 +363,8 @@ impl VolatilityShield {
         if !guardians.contains(guardian.clone()) {
             return Err(Error::Unauthorized);
         }
+
+        Self::prune_old_proposals_internal(&env);
 
         let mut proposals: Map<u64, Proposal> = env
             .storage()
@@ -366,8 +389,9 @@ impl VolatilityShield {
             .get(&DataKey::Threshold)
             .unwrap_or(1);
         if proposal.approvals.len() >= threshold {
-            Self::execute_action(&env, &proposal.action, proposal.proposed_at)?;
+            Self::execute_action(&env, &guardian, &proposal.action, proposal.proposed_at)?;
             proposal.executed = true;
+            proposal.executed_ledger = env.ledger().sequence();
         }
 
         proposals.set(proposal_id, proposal);
@@ -464,14 +488,17 @@ impl VolatilityShield {
         Ok(())
     }
 
-    fn execute_action(env: &Env, action: &ActionType, proposed_at: u64) -> Result<(), Error> {
+    fn execute_action(
+        env: &Env,
+        caller: &Address,
+        action: &ActionType,
+        proposed_at: u64,
+    ) -> Result<(), Error> {
         // Check if timelock has elapsed
         Self::assert_timelock_elapsed(env, proposed_at)?;
         match action {
             ActionType::SetPaused(state) => {
-                env.storage().instance().set(&DataKey::Paused, state);
-                env.events()
-                    .publish((soroban_sdk::Symbol::new(env, "Paused"),), state);
+                Self::record_pause_change(env, caller.clone(), *state);
             }
             ActionType::AddStrategy(strategy) => {
                 Self::internal_add_strategy(env, strategy.clone())?;
@@ -552,10 +579,23 @@ impl VolatilityShield {
             .set(&DataKey::Proposals, &Map::<u64, Proposal>::new(&env));
         env.storage()
             .instance()
+            .set(&DataKey::ProposalIds, &Vec::<u64>::new(&env));
+        env.storage()
+            .instance()
             .set(&DataKey::TimelockDuration, &0_u64);
         env.storage()
             .instance()
             .set(&DataKey::NextProposalId, &1_u64);
+        env.storage()
+            .instance()
+            .set(&DataKey::ProposalTtlLedgers, &DEFAULT_PROPOSAL_TTL_LEDGERS);
+        env.storage().instance().set(
+            &DataKey::PauseHistory,
+            &Vec::<(u64, Address, bool)>::new(&env),
+        );
+        env.storage()
+            .instance()
+            .set(&DataKey::SharePriceHistory, &Vec::<(u64, i128)>::new(&env));
 
         // Initialize vault state to zero
         env.storage().instance().set(&DataKey::TotalAssets, &0_i128);
@@ -589,11 +629,11 @@ impl VolatilityShield {
     /// Deposit assets into the vault.
     /// If asset is not the default/primary asset, it must be in the accepted assets list.
     /// The user will receive shares in return, proportional to the current share price.
-    /// 
+    ///
     /// Compliance checks:
     /// - If blocklist mode is active, blocked users cannot deposit
     /// - If allowlist mode is active, only allowlisted users can deposit
-    /// 
+    ///
     /// @param from The address of the user depositing.
     /// @param asset The address of the asset being deposited.
     /// @param amount The amount of assets to deposit.
@@ -1442,6 +1482,7 @@ impl VolatilityShield {
             (soroban_sdk::Symbol::new(&env, "VaultSnapshot"),),
             (final_total_assets, final_total_shares, allocations),
         );
+        Self::record_share_price_snapshot(env);
 
         Ok(())
     }
@@ -1672,15 +1713,15 @@ impl VolatilityShield {
                 balance: before_balance,
                 ledger: current_ledger,
             };
-            
+
             let history_key = DataKey::StrategyYieldSnapshot(addr.clone());
-            let mut history: YieldHistory = env
-                .storage()
-                .instance()
-                .get(&history_key)
-                .unwrap_or(YieldHistory {
-                    snapshots: Vec::new(&env),
-                });
+            let mut history: YieldHistory =
+                env.storage()
+                    .instance()
+                    .get(&history_key)
+                    .unwrap_or(YieldHistory {
+                        snapshots: Vec::new(&env),
+                    });
             history.snapshots.push_back(snapshot);
             env.storage().instance().set(&history_key, &history);
         }
@@ -1709,21 +1750,22 @@ impl VolatilityShield {
                 balance: after_balance,
                 ledger: current_ledger,
             };
-            
+
             let history_key = DataKey::StrategyYieldSnapshot(addr.clone());
-            let mut history: YieldHistory = env
-                .storage()
-                .instance()
-                .get(&history_key)
-                .unwrap_or(YieldHistory {
-                    snapshots: Vec::new(&env),
-                });
+            let mut history: YieldHistory =
+                env.storage()
+                    .instance()
+                    .get(&history_key)
+                    .unwrap_or(YieldHistory {
+                        snapshots: Vec::new(&env),
+                    });
             history.snapshots.push_back(snapshot);
             env.storage().instance().set(&history_key, &history);
         }
 
         let total_assets_after = Self::total_assets(&env);
         let total_shares_after = Self::total_shares(&env);
+        Self::record_share_price_snapshot(&env);
         env.events().publish(
             (soroban_sdk::Symbol::new(&env, "Harvest"),),
             (total_yield, total_assets_after, total_shares_after),
@@ -1918,7 +1960,7 @@ impl VolatilityShield {
     pub fn get_strategy_apy(env: Env, strategy: Address, periods: u32) -> i128 {
         let history_key = DataKey::StrategyYieldSnapshot(strategy.clone());
         let history: Option<YieldHistory> = env.storage().instance().get(&history_key);
-        
+
         match history {
             Some(h) if h.snapshots.len() >= 2 => {
                 let snapshots = h.snapshots;
@@ -1956,14 +1998,18 @@ impl VolatilityShield {
                 }
 
                 // Calculate growth rate
-                let growth = end_balance.checked_mul(10_000).unwrap().checked_div(start_balance).unwrap();
+                let growth = end_balance
+                    .checked_mul(10_000)
+                    .unwrap()
+                    .checked_div(start_balance)
+                    .unwrap();
                 let growth_bps = growth.saturating_sub(10_000);
 
                 // Annualize: assume ~10 ledgers per second on Stellar testnet
                 // This is a simplification; in production use actual timestamp
                 let ledgers_per_year = 10 * 60 * 60 * 24 * 365; // ~315 million
                 let periods_per_year = ledgers_per_year / ledger_diff as i128;
-                
+
                 if periods_per_year <= 0 {
                     return growth_bps;
                 }
@@ -2071,7 +2117,10 @@ impl VolatilityShield {
             .instance()
             .set(&DataKey::OracleCircuitBreakerActive, &true);
         env.events().publish(
-            (soroban_sdk::Symbol::new(&env, "OracleCircuitBreakerActivated"),),
+            (soroban_sdk::Symbol::new(
+                &env,
+                "OracleCircuitBreakerActivated",
+            ),),
             env.ledger().timestamp(),
         );
     }
@@ -2155,7 +2204,9 @@ impl VolatilityShield {
             .unwrap_or(Vec::new(&env));
         if !blocklist.contains(user.clone()) {
             blocklist.push_back(user.clone());
-            env.storage().instance().set(&DataKey::Blocklist, &blocklist);
+            env.storage()
+                .instance()
+                .set(&DataKey::Blocklist, &blocklist);
             env.events()
                 .publish((soroban_sdk::Symbol::new(&env, "UserBlocked"),), user);
         }
@@ -2172,7 +2223,9 @@ impl VolatilityShield {
             .unwrap_or(Vec::new(&env));
         if let Some(index) = blocklist.iter().position(|x| x == user) {
             blocklist.remove(index as u32);
-            env.storage().instance().set(&DataKey::Blocklist, &blocklist);
+            env.storage()
+                .instance()
+                .set(&DataKey::Blocklist, &blocklist);
         }
     }
 
@@ -2187,7 +2240,9 @@ impl VolatilityShield {
             .unwrap_or(Vec::new(&env));
         if !allowlist.contains(user.clone()) {
             allowlist.push_back(user.clone());
-            env.storage().instance().set(&DataKey::Allowlist, &allowlist);
+            env.storage()
+                .instance()
+                .set(&DataKey::Allowlist, &allowlist);
             env.events()
                 .publish((soroban_sdk::Symbol::new(&env, "UserAllowlisted"),), user);
         }
@@ -2204,7 +2259,9 @@ impl VolatilityShield {
             .unwrap_or(Vec::new(&env));
         if let Some(index) = allowlist.iter().position(|x| x == user) {
             allowlist.remove(index as u32);
-            env.storage().instance().set(&DataKey::Allowlist, &allowlist);
+            env.storage()
+                .instance()
+                .set(&DataKey::Allowlist, &allowlist);
         }
     }
 
@@ -2298,6 +2355,67 @@ impl VolatilityShield {
             .unwrap_or(1)
     }
 
+    pub fn set_proposal_ttl_ledgers(env: Env, ledgers: u32) {
+        Self::require_admin(&env);
+        env.storage()
+            .instance()
+            .set(&DataKey::ProposalTtlLedgers, &ledgers);
+        env.events().publish(
+            (soroban_sdk::Symbol::new(&env, "ProposalTtlLedgers"),),
+            ledgers,
+        );
+    }
+
+    pub fn get_proposal_ttl_ledgers(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::ProposalTtlLedgers)
+            .unwrap_or(DEFAULT_PROPOSAL_TTL_LEDGERS)
+    }
+
+    pub fn prune_old_proposals(env: Env) -> u32 {
+        Self::require_admin(&env);
+        Self::prune_old_proposals_internal(&env)
+    }
+
+    pub fn list_proposals(env: Env, offset: u32, limit: u32) -> Vec<Proposal> {
+        if limit == 0 {
+            return Vec::new(&env);
+        }
+
+        let proposal_ids: Vec<u64> = env
+            .storage()
+            .instance()
+            .get(&DataKey::ProposalIds)
+            .unwrap_or(Vec::new(&env));
+        let proposals: Map<u64, Proposal> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Proposals)
+            .unwrap_or(Map::new(&env));
+
+        let mut listed = Vec::new(&env);
+        let end = offset.saturating_add(limit);
+        let mut index = offset;
+        while index < proposal_ids.len() && index < end {
+            let proposal_id = proposal_ids.get(index).unwrap();
+            if let Some(proposal) = proposals.get(proposal_id) {
+                listed.push_back(proposal);
+            }
+            index += 1;
+        }
+        listed
+    }
+
+    pub fn get_proposal(env: Env, proposal_id: u64) -> Option<Proposal> {
+        let proposals: Map<u64, Proposal> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Proposals)
+            .unwrap_or(Map::new(&env));
+        proposals.get(proposal_id)
+    }
+
     // ── Internal Helpers ──────────────────────
     pub fn take_fees(env: &Env, amount: i128) -> i128 {
         let fee_pct = Self::fee_percentage(&env);
@@ -2381,11 +2499,134 @@ impl VolatilityShield {
         admin
     }
 
+    fn proposal_ttl_ledgers(env: &Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::ProposalTtlLedgers)
+            .unwrap_or(DEFAULT_PROPOSAL_TTL_LEDGERS)
+    }
+
+    fn prune_old_proposals_internal(env: &Env) -> u32 {
+        let mut proposals: Map<u64, Proposal> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Proposals)
+            .unwrap_or(Map::new(env));
+        let proposal_ids: Vec<u64> = env
+            .storage()
+            .instance()
+            .get(&DataKey::ProposalIds)
+            .unwrap_or(Vec::new(env));
+        let ttl = Self::proposal_ttl_ledgers(env);
+        let current_ledger = env.ledger().sequence();
+        let mut retained_ids = Vec::new(env);
+        let mut pruned = 0_u32;
+
+        for proposal_id in proposal_ids.iter() {
+            if let Some(proposal) = proposals.get(proposal_id) {
+                let expired = proposal.executed
+                    && proposal.executed_ledger > 0
+                    && current_ledger.saturating_sub(proposal.executed_ledger) >= ttl;
+                if expired {
+                    proposals.remove(proposal_id);
+                    pruned = pruned.saturating_add(1);
+                } else {
+                    retained_ids.push_back(proposal_id);
+                }
+            }
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::Proposals, &proposals);
+        env.storage()
+            .instance()
+            .set(&DataKey::ProposalIds, &retained_ids);
+
+        if pruned > 0 {
+            env.events()
+                .publish((soroban_sdk::Symbol::new(env, "ProposalsPruned"),), pruned);
+        }
+
+        pruned
+    }
+
+    fn record_pause_change(env: &Env, caller: Address, state: bool) {
+        env.storage().instance().set(&DataKey::Paused, &state);
+        let timestamp = env.ledger().timestamp();
+        let mut history: Vec<(u64, Address, bool)> = env
+            .storage()
+            .instance()
+            .get(&DataKey::PauseHistory)
+            .unwrap_or(Vec::new(env));
+        history.push_back((timestamp, caller.clone(), state));
+        env.storage()
+            .instance()
+            .set(&DataKey::PauseHistory, &history);
+
+        let event_name = if state {
+            "VaultPaused"
+        } else {
+            "VaultUnpaused"
+        };
+        env.events().publish(
+            (soroban_sdk::Symbol::new(env, event_name),),
+            (caller, timestamp),
+        );
+    }
+
+    fn record_share_price_snapshot(env: &Env) {
+        let mut history: Vec<(u64, i128)> = env
+            .storage()
+            .instance()
+            .get(&DataKey::SharePriceHistory)
+            .unwrap_or(Vec::new(env));
+        if history.len() >= SHARE_PRICE_HISTORY_CAP {
+            history.remove(0);
+        }
+        history.push_back((env.ledger().timestamp(), Self::get_share_price(env)));
+        env.storage()
+            .instance()
+            .set(&DataKey::SharePriceHistory, &history);
+    }
+
     // ── Emergency Pause ──────────────────────────
     pub fn set_paused(env: Env, state: bool) {
-        Self::require_admin(&env);
-        env.storage().instance().set(&DataKey::Paused, &state);
-        env.events().publish((symbol_short!("paused"),), state);
+        let admin = Self::require_admin(&env);
+        Self::record_pause_change(&env, admin, state);
+    }
+
+    pub fn get_pause_history(env: Env) -> Vec<(u64, Address, bool)> {
+        env.storage()
+            .instance()
+            .get(&DataKey::PauseHistory)
+            .unwrap_or(Vec::new(&env))
+    }
+
+    pub fn get_share_price_history(env: Env, limit: u32) -> Vec<(u64, i128)> {
+        if limit == 0 {
+            return Vec::new(&env);
+        }
+
+        let history: Vec<(u64, i128)> = env
+            .storage()
+            .instance()
+            .get(&DataKey::SharePriceHistory)
+            .unwrap_or(Vec::new(&env));
+        if history.is_empty() {
+            return Vec::new(&env);
+        }
+
+        let start = if history.len() > limit {
+            history.len() - limit
+        } else {
+            0
+        };
+        let mut recent = Vec::new(&env);
+        for index in start..history.len() {
+            recent.push_back(history.get(index).unwrap());
+        }
+        recent
     }
 
     // ── Deposit / Withdrawal Caps ──────────────────────────
@@ -2612,12 +2853,24 @@ impl VolatilityShield {
             .instance()
             .get(&DataKey::Threshold)
             .unwrap_or(0);
-        let proposals: Vec<Proposal> = env
+        let proposal_ids: Vec<u64> = env
+            .storage()
+            .instance()
+            .get(&DataKey::ProposalIds)
+            .unwrap_or(Vec::new(&env));
+        let proposals: Map<u64, Proposal> = env
             .storage()
             .instance()
             .get(&DataKey::Proposals)
-            .unwrap_or(Vec::new(&env));
-        let active_proposal_count = proposals.iter().filter(|p| !p.executed).count() as u32;
+            .unwrap_or(Map::new(&env));
+        let mut active_proposal_count = 0_u32;
+        for proposal_id in proposal_ids.iter() {
+            if let Some(proposal) = proposals.get(proposal_id) {
+                if !proposal.executed {
+                    active_proposal_count = active_proposal_count.saturating_add(1);
+                }
+            }
+        }
         GovernanceSummary {
             guardians,
             threshold,

--- a/smartcontract/contracts/volatility_shield/src/lib.rs
+++ b/smartcontract/contracts/volatility_shield/src/lib.rs
@@ -309,7 +309,7 @@ impl VolatilityShield {
             id,
             proposer: proposer.clone(),
             action: action.clone(),
-            approvals: soroban_sdk::vec![&env, proposer],
+            approvals: soroban_sdk::vec![&env, proposer.clone()],
             executed: false,
             executed_ledger: 0,
             proposed_at,
@@ -393,7 +393,7 @@ impl VolatilityShield {
             return Err(Error::AlreadyApproved);
         }
 
-        proposal.approvals.push_back(guardian);
+        proposal.approvals.push_back(guardian.clone());
 
         let threshold: u32 = env
             .storage()

--- a/smartcontract/contracts/volatility_shield/src/test.rs
+++ b/smartcontract/contracts/volatility_shield/src/test.rs
@@ -867,6 +867,199 @@ fn test_timelock_events_emitted() {
     // TimelockExecuted event should be emitted during execution
 }
 
+#[test]
+fn test_proposal_pruning_preserves_active_and_recent_proposals() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, VolatilityShield);
+    let client = VolatilityShieldClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let guardian = Address::generate(&env);
+    let asset = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let guardians = soroban_sdk::vec![&env, admin.clone(), guardian.clone()];
+    client.init(&admin, &asset, &oracle, &treasury, &0u32, &guardians, &1u32);
+    client.set_proposal_ttl_ledgers(&5u32);
+
+    env.ledger().set_sequence_number(10);
+    env.ledger().set_timestamp(1000);
+    let old_id = client.propose_action(&admin, &ActionType::SetPaused(true));
+    assert!(client.get_proposal(&old_id).unwrap().executed);
+
+    client.set_threshold(&2u32);
+    env.ledger().set_sequence_number(12);
+    env.ledger().set_timestamp(1200);
+    let active_id = client.propose_action(&admin, &ActionType::SetPaused(false));
+    assert!(!client.get_proposal(&active_id).unwrap().executed);
+
+    client.set_threshold(&1u32);
+    env.ledger().set_sequence_number(15);
+    env.ledger().set_timestamp(1500);
+    let recent_id = client.propose_action(&admin, &ActionType::SetPaused(true));
+    assert!(client.get_proposal(&recent_id).unwrap().executed);
+
+    env.ledger().set_sequence_number(16);
+    env.ledger().set_timestamp(1600);
+    assert_eq!(client.prune_old_proposals(), 1);
+    assert!(client.get_proposal(&old_id).is_none());
+    assert!(!client.get_proposal(&active_id).unwrap().executed);
+    assert!(client.get_proposal(&recent_id).unwrap().executed);
+
+    let proposals = client.list_proposals(&0u32, &10u32);
+    assert_eq!(proposals.len(), 2);
+    assert_eq!(proposals.get(0).unwrap().id, active_id);
+    assert_eq!(proposals.get(1).unwrap().id, recent_id);
+
+    client.set_threshold(&2u32);
+    client.approve_action(&guardian, &active_id);
+    assert!(!client.is_paused());
+
+    client.set_threshold(&1u32);
+    env.ledger().set_sequence_number(17);
+    env.ledger().set_timestamp(1700);
+    let new_id = client.propose_action(&admin, &ActionType::SetPaused(true));
+    assert_eq!(new_id, 4);
+    assert!(client.get_proposal(&new_id).unwrap().executed);
+}
+
+#[test]
+fn test_list_proposals_pagination_and_get_proposal() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, VolatilityShield);
+    let client = VolatilityShieldClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let asset = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let guardians = soroban_sdk::vec![&env, admin.clone()];
+    client.init(&admin, &asset, &oracle, &treasury, &0u32, &guardians, &1u32);
+
+    let first_id = client.propose_action(&admin, &ActionType::SetPaused(true));
+    let second_id = client.propose_action(&admin, &ActionType::SetPaused(false));
+    let third_id = client.propose_action(&admin, &ActionType::SetPaused(true));
+
+    let first_page = client.list_proposals(&0u32, &2u32);
+    assert_eq!(first_page.len(), 2);
+    assert_eq!(first_page.get(0).unwrap().id, first_id);
+    assert_eq!(first_page.get(1).unwrap().id, second_id);
+
+    let second_page = client.list_proposals(&1u32, &2u32);
+    assert_eq!(second_page.len(), 2);
+    assert_eq!(second_page.get(0).unwrap().id, second_id);
+    assert_eq!(second_page.get(1).unwrap().id, third_id);
+
+    let proposal = client.get_proposal(&second_id).unwrap();
+    assert_eq!(proposal.id, second_id);
+    assert!(proposal.executed);
+    assert!(client.get_proposal(&999u64).is_none());
+
+    let summary = client.get_governance_summary();
+    assert_eq!(summary.active_proposal_count, 0);
+}
+
+#[test]
+fn test_pause_history_contains_pause_and_unpause() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, VolatilityShield);
+    let client = VolatilityShieldClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let asset = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let guardians = soroban_sdk::vec![&env, admin.clone()];
+    client.init(&admin, &asset, &oracle, &treasury, &0u32, &guardians, &1u32);
+
+    env.ledger().set_timestamp(100);
+    client.set_paused(&true);
+    env.ledger().set_timestamp(150);
+    client.set_paused(&false);
+
+    let history = client.get_pause_history();
+    assert_eq!(history.len(), 2);
+
+    let first = history.get(0).unwrap();
+    assert_eq!(first.0, 100);
+    assert_eq!(first.1, admin);
+    assert!(first.2);
+
+    let second = history.get(1).unwrap();
+    assert_eq!(second.0, 150);
+    assert_eq!(second.1, admin);
+    assert!(!second.2);
+    assert!(!client.is_paused());
+}
+
+#[test]
+fn test_share_price_history_grows_on_harvest() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, VolatilityShield);
+    let client = VolatilityShieldClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let asset = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let guardians = soroban_sdk::vec![&env, admin.clone()];
+    client.init(&admin, &asset, &oracle, &treasury, &0u32, &guardians, &1u32);
+
+    assert_eq!(client.get_share_price_history(&10u32).len(), 0);
+
+    client.set_total_assets(&200);
+    client.set_total_shares(&100);
+
+    let strategy = env.register_contract(None, mock_strategy::MockStrategy);
+    client.propose_action(&admin, &ActionType::AddStrategy(strategy));
+
+    env.ledger().set_timestamp(200);
+    assert_eq!(client.harvest(), 0);
+
+    let history = client.get_share_price_history(&10u32);
+    assert_eq!(history.len(), 1);
+    let entry = history.get(0).unwrap();
+    assert_eq!(entry.0, 200);
+    assert_eq!(entry.1, 2_000_000_000);
+}
+
+#[test]
+fn test_share_price_history_cap_evicts_oldest() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, VolatilityShield);
+    let client = VolatilityShieldClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let asset = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let guardians = soroban_sdk::vec![&env, admin.clone()];
+    client.init(&admin, &asset, &oracle, &treasury, &0u32, &guardians, &1u32);
+
+    let strategy = env.register_contract(None, mock_strategy::MockStrategy);
+    client.propose_action(&admin, &ActionType::AddStrategy(strategy));
+
+    for offset in 0..366u32 {
+        env.ledger().set_timestamp(1_000 + offset as u64);
+        client.harvest();
+    }
+
+    let history = client.get_share_price_history(&400u32);
+    assert_eq!(history.len(), 365);
+    assert_eq!(history.get(0).unwrap().0, 1_001);
+    assert_eq!(history.get(364).unwrap().0, 1_365);
+}
+
 // ── Withdrawal Queue Tests ─────────────────────────
 
 #[test]
@@ -2041,7 +2234,9 @@ fn test_strategy_yield_snapshots_recorded_on_harvest() {
     let treasury = Address::generate(&env);
     let guardians = soroban_sdk::vec![&env, admin.clone()];
 
-    client.init(&admin, &token_id, &oracle, &treasury, &0u32, &guardians, &1u32);
+    client.init(
+        &admin, &token_id, &oracle, &treasury, &0u32, &guardians, &1u32,
+    );
 
     let mock_strategy_id = env.register_contract(None, mock_strategy::MockStrategy);
     let mock_client = mock_strategy::MockStrategyClient::new(&env, &mock_strategy_id);
@@ -2084,7 +2279,9 @@ fn test_get_strategy_apy_returns_basis_points() {
     let treasury = Address::generate(&env);
     let guardians = soroban_sdk::vec![&env, admin.clone()];
 
-    client.init(&admin, &token_id, &oracle, &treasury, &0u32, &guardians, &1u32);
+    client.init(
+        &admin, &token_id, &oracle, &treasury, &0u32, &guardians, &1u32,
+    );
 
     let mock_strategy_id = env.register_contract(None, mock_strategy::MockStrategy);
     let mock_client = mock_strategy::MockStrategyClient::new(&env, &mock_strategy_id);
@@ -2127,7 +2324,9 @@ fn test_get_best_performing_strategy() {
     let treasury = Address::generate(&env);
     let guardians = soroban_sdk::vec![&env, admin.clone()];
 
-    client.init(&admin, &token_id, &oracle, &treasury, &0u32, &guardians, &1u32);
+    client.init(
+        &admin, &token_id, &oracle, &treasury, &0u32, &guardians, &1u32,
+    );
 
     let strategy1_id = env.register_contract(None, mock_strategy::MockStrategy);
     let strategy1_client = mock_strategy::MockStrategyClient::new(&env, &strategy1_id);
@@ -2432,7 +2631,9 @@ fn test_blocked_user_cannot_deposit() {
     let treasury = Address::generate(&env);
     let guardians = soroban_sdk::vec![&env, admin.clone()];
 
-    client.init(&admin, &token_id, &oracle, &treasury, &0u32, &guardians, &1u32);
+    client.init(
+        &admin, &token_id, &oracle, &treasury, &0u32, &guardians, &1u32,
+    );
 
     let blocked_user = Address::generate(&env);
     client.add_to_blocklist(&blocked_user);
@@ -2462,11 +2663,13 @@ fn test_non_allowlisted_user_cannot_deposit() {
     let treasury = Address::generate(&env);
     let guardians = soroban_sdk::vec![&env, admin.clone()];
 
-    client.init(&admin, &token_id, &oracle, &treasury, &0u32, &guardians, &1u32);
+    client.init(
+        &admin, &token_id, &oracle, &treasury, &0u32, &guardians, &1u32,
+    );
 
     let allowed_user = Address::generate(&env);
     let non_allowed_user = Address::generate(&env);
-    
+
     client.add_to_allowlist(&allowed_user);
     client.set_allowlist_mode(&true);
 
@@ -2493,7 +2696,9 @@ fn test_allowlisted_user_can_deposit() {
     let treasury = Address::generate(&env);
     let guardians = soroban_sdk::vec![&env, admin.clone()];
 
-    client.init(&admin, &token_id, &oracle, &treasury, &0u32, &guardians, &1u32);
+    client.init(
+        &admin, &token_id, &oracle, &treasury, &0u32, &guardians, &1u32,
+    );
 
     let allowed_user = Address::generate(&env);
     client.add_to_allowlist(&allowed_user);
@@ -2504,7 +2709,7 @@ fn test_allowlisted_user_can_deposit() {
 
     // Deposit should succeed
     client.deposit(&allowed_user, &token_id, &100);
-    
+
     // Verify deposit succeeded
     let balance = client.balance(&allowed_user);
     assert!(balance > 0);


### PR DESCRIPTION
## Summary
- add proposal TTL storage, pruning, pagination, and single-proposal reads
- record pause/unpause history with caller and timestamp and emit structured pause events
- add capped share price history snapshots for harvests and rebalances with coverage for the new contract reads

## Notes
- tests were not run per request

Closes #326
Closes #327
Closes #328
Closes #329