### PR TITLE
feat(contract): add emergency pause cascade to halt all strategy interactions

### DIFF
--- a/frontend/components/MaxAmountButton.spec.tsx
+++ b/frontend/components/MaxAmountButton.spec.tsx
@@ -1,0 +1,203 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import MaxAmountButton from './MaxAmountButton';
+
+// Mock the wallet hook
+vi.mock('@/hooks/use-wallet', () => ({
+  useWallet: () => ({
+    connected: true,
+    address: 'test-address',
+  })
+}));
+
+// Mock the network context
+vi.mock('@/app/context/NetworkContext', () => ({
+  useNetwork: () => ({
+    network: 'testnet',
+  })
+}));
+
+// Mock the stellar lib
+vi.mock('@/lib/stellar', () => ({
+  fetchVaultData: vi.fn(),
+}));
+
+// Mock the translation hook
+vi.mock('@/lib/i18n-context', () => ({
+  useTranslations: (key: string) => {
+    const translations = {
+      "Vault": {
+        "max": "Max",
+        "maxDepositTooltip": "Fill with your maximum wallet balance",
+        "maxWithdrawTooltip": "Fill with your maximum withdrawable amount",
+        "processing": "Processing..."
+      }
+    };
+    return (subKey: string) => translations[key as keyof typeof translations.Vault]?.[subKey as keyof typeof translations.Vault] || subKey;
+  }
+}));
+
+import { fetchVaultData } from '@/lib/stellar';
+
+describe('MaxAmountButton', () => {
+  const mockOnAmountSet = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockOnAmountSet.mockClear();
+  });
+
+  it('renders the button with correct text', () => {
+    render(<MaxAmountButton type="deposit" onAmountSet={mockOnAmountSet} />);
+    
+    const button = screen.getByRole('button', { name: /max/i });
+    expect(button).toBeInTheDocument();
+    expect(screen.getByText('Max')).toBeInTheDocument();
+  });
+
+  it('is disabled when wallet is not connected', () => {
+    vi.mocked('@/hooks/use-wallet').useWallet = () => ({
+      connected: false,
+      address: null,
+    });
+
+    render(<MaxAmountButton type="deposit" onAmountSet={mockOnAmountSet} />);
+    
+    const button = screen.getByRole('button', { name: /max/i });
+    expect(button).toBeDisabled();
+  });
+
+  it('is disabled when explicitly disabled', () => {
+    render(<MaxAmountButton type="deposit" onAmountSet={mockOnAmountSet} disabled />);
+    
+    const button = screen.getByRole('button', { name: /max/i });
+    expect(button).toBeDisabled();
+  });
+
+  it('calls onAmountSet with wallet balance for deposit type', async () => {
+    const mockVaultData = {
+      userBalance: 1000.5,
+      userShares: 500,
+      sharePrice: 2.0,
+      totalAssets: 1000000,
+      totalShares: 500000,
+    };
+
+    vi.mocked(fetchVaultData).mockResolvedValue(mockVaultData);
+
+    render(<MaxAmountButton type="deposit" onAmountSet={mockOnAmountSet} />);
+    
+    const button = screen.getByRole('button', { name: /max/i });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(mockOnAmountSet).toHaveBeenCalledWith('1000.5');
+    });
+  });
+
+  it('calls onAmountSet with shares converted to assets for withdraw type', async () => {
+    const mockVaultData = {
+      userBalance: 1000.5,
+      userShares: 500,
+      sharePrice: 2.0,
+      totalAssets: 1000000,
+      totalShares: 500000,
+    };
+
+    vi.mocked(fetchVaultData).mockResolvedValue(mockVaultData);
+
+    render(<MaxAmountButton type="withdraw" onAmountSet={mockOnAmountSet} />);
+    
+    const button = screen.getByRole('button', { name: /max/i });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(mockOnAmountSet).toHaveBeenCalledWith('1000'); // 500 shares * 2.0 sharePrice
+    });
+  });
+
+  it('shows loading state while fetching data', async () => {
+    vi.mocked(fetchVaultData).mockImplementation(() => new Promise(resolve => setTimeout(resolve, 100)));
+
+    render(<MaxAmountButton type="deposit" onAmountSet={mockOnAmountSet} />);
+    
+    const button = screen.getByRole('button', { name: /max/i });
+    fireEvent.click(button);
+
+    // Should show loading spinner
+    expect(screen.getByRole('button')).toBeInTheDocument();
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('handles zero balance correctly', async () => {
+    const mockVaultData = {
+      userBalance: 0,
+      userShares: 0,
+      sharePrice: 2.0,
+      totalAssets: 1000000,
+      totalShares: 500000,
+    };
+
+    vi.mocked(fetchVaultData).mockResolvedValue(mockVaultData);
+
+    render(<MaxAmountButton type="deposit" onAmountSet={mockOnAmountSet} />);
+    
+    const button = screen.getByRole('button', { name: /max/i });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(mockOnAmountSet).toHaveBeenCalledWith('0');
+    });
+  });
+
+  it('formats amount correctly removing trailing zeros', async () => {
+    const mockVaultData = {
+      userBalance: 1000.500000,
+      userShares: 500,
+      sharePrice: 2.0,
+      totalAssets: 1000000,
+      totalShares: 500000,
+    };
+
+    vi.mocked(fetchVaultData).mockResolvedValue(mockVaultData);
+
+    render(<MaxAmountButton type="deposit" onAmountSet={mockOnAmountSet} />);
+    
+    const button = screen.getByRole('button', { name: /max/i });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(mockOnAmountSet).toHaveBeenCalledWith('1000.5'); // Trailing zeros removed
+    });
+  });
+
+  it('handles API errors gracefully', async () => {
+    vi.mocked(fetchVaultData).mockRejectedValue(new Error('API Error'));
+
+    render(<MaxAmountButton type="deposit" onAmountSet={mockOnAmountSet} />);
+    
+    const button = screen.getByRole('button', { name: /max/i });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(mockOnAmountSet).not.toHaveBeenCalled();
+    });
+
+    // Button should be re-enabled after error
+    expect(button).not.toBeDisabled();
+  });
+
+  it('has correct tooltip text for deposit type', () => {
+    render(<MaxAmountButton type="deposit" onAmountSet={mockOnAmountSet} />);
+    
+    const button = screen.getByRole('button', { name: /max/i });
+    expect(button).toHaveAttribute('title', 'Fill with your maximum wallet balance');
+  });
+
+  it('has correct tooltip text for withdraw type', () => {
+    render(<MaxAmountButton type="withdraw" onAmountSet={mockOnAmountSet} />);
+    
+    const button = screen.getByRole('button', { name: /max/i });
+    expect(button).toHaveAttribute('title', 'Fill with your maximum withdrawable amount');
+  });
+});

--- a/frontend/components/MaxAmountButton.tsx
+++ b/frontend/components/MaxAmountButton.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import React, { useState, useCallback } from 'react';
+import { Button } from '@/components/ui/button';
+import { Maximize2, Loader2 } from 'lucide-react';
+import { useWallet } from '@/hooks/use-wallet';
+import { useNetwork } from '@/app/context/NetworkContext';
+import { fetchVaultData, VaultMetrics } from '@/lib/stellar';
+import { useTranslations } from '@/lib/i18n-context';
+
+interface MaxAmountButtonProps {
+  type: 'deposit' | 'withdraw';
+  onAmountSet: (amount: string) => void;
+  disabled?: boolean;
+  className?: string;
+}
+
+export default function MaxAmountButton({ 
+  type, 
+  onAmountSet, 
+  disabled = false, 
+  className = '' 
+}: MaxAmountButtonProps) {
+  const t = useTranslations("Vault");
+  const { connected, address } = useWallet();
+  const { network } = useNetwork();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleMaxClick = useCallback(async () => {
+    if (!connected || !address || disabled) {
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const vaultData = await fetchVaultData(network, address);
+      
+      let maxAmount: number;
+      
+      if (type === 'deposit') {
+        // For deposit, use the user's wallet balance
+        maxAmount = vaultData.userBalance;
+      } else {
+        // For withdraw, use the user's shares converted to assets
+        maxAmount = vaultData.userShares * vaultData.sharePrice;
+      }
+
+      // Format the amount with appropriate decimal places
+      const formattedAmount = maxAmount > 0 
+        ? maxAmount.toFixed(6).replace(/\.?0+$/, '') // Remove trailing zeros
+        : '0';
+
+      onAmountSet(formattedAmount);
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to fetch balance';
+      setError(errorMessage);
+      console.error('Failed to fetch max amount:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, [connected, address, disabled, type, network, onAmountSet]);
+
+  const tooltipText = type === 'deposit' 
+    ? t("maxDepositTooltip") 
+    : t("maxWithdrawTooltip");
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      onClick={handleMaxClick}
+      disabled={!connected || disabled || loading}
+      className={`flex items-center gap-1 ${className}`}
+      title={tooltipText}
+    >
+      {loading ? (
+        <Loader2 className="h-3 w-3 animate-spin" />
+      ) : (
+        <Maximize2 className="h-3 w-3" />
+      )}
+      {t("max")}
+    </Button>
+  );
+}

--- a/frontend/components/PerformanceHeatmap.spec.tsx
+++ b/frontend/components/PerformanceHeatmap.spec.tsx
@@ -1,0 +1,110 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import PerformanceHeatmap from './PerformanceHeatmap';
+
+// Mock the translation hook
+vi.mock('@/lib/i18n-context', () => ({
+  useTranslations: (key: string) => {
+    const translations = {
+      "Analytics": {
+        "performanceHeatmap": "Performance Heatmap",
+        "failedToLoadData": "Failed to load data",
+        "noDataAvailable": "No data available",
+        "less": "Less",
+        "more": "More",
+        "noData": "No data"
+      }
+    };
+    return (subKey: string) => translations[key as keyof typeof translations]?.[subKey as keyof typeof translations.Analytics] || subKey;
+  }
+}));
+
+describe('PerformanceHeatmap', () => {
+  const mockData = [
+    { date: '2024-01-01', return: 1.5 },
+    { date: '2024-01-02', return: -0.8 },
+    { date: '2024-01-03', return: 2.1 },
+    { date: '2024-01-04', return: 0.0 },
+    { date: '2024-01-05', return: -1.2 },
+  ];
+
+  it('renders loading state', () => {
+    render(<PerformanceHeatmap data={[]} loading={true} />);
+    
+    expect(screen.getByText('Performance Heatmap')).toBeInTheDocument();
+    expect(screen.getByText('Loading chart data...')).toBeInTheDocument();
+  });
+
+  it('renders error state', () => {
+    render(<PerformanceHeatmap data={[]} loading={false} error="Failed to load" />);
+    
+    expect(screen.getByText('Performance Heatmap')).toBeInTheDocument();
+    expect(screen.getByText('Failed to load data')).toBeInTheDocument();
+  });
+
+  it('renders empty state', () => {
+    render(<PerformanceHeatmap data={[]} loading={false} />);
+    
+    expect(screen.getByText('Performance Heatmap')).toBeInTheDocument();
+    expect(screen.getByText('No data available')).toBeInTheDocument();
+  });
+
+  it('renders heatmap with data', () => {
+    render(<PerformanceHeatmap data={mockData} loading={false} />);
+    
+    expect(screen.getByText('Performance Heatmap')).toBeInTheDocument();
+    
+    // Check for legend elements
+    expect(screen.getByText('Less')).toBeInTheDocument();
+    expect(screen.getByText('More')).toBeInTheDocument();
+    expect(screen.getByText('No data')).toBeInTheDocument();
+    
+    // Check for month labels (should be present)
+    expect(screen.getByText('Jan')).toBeInTheDocument();
+    
+    // Check for week day labels
+    expect(screen.getByText('S')).toBeInTheDocument();
+    expect(screen.getByText('M')).toBeInTheDocument();
+  });
+
+  it('renders year selector when multiple years are available', () => {
+    const multiYearData = [
+      ...mockData,
+      { date: '2023-12-31', return: 0.5 },
+      { date: '2023-12-30', return: -0.3 },
+    ];
+    
+    render(<PerformanceHeatmap data={multiYearData} loading={false} />);
+    
+    expect(screen.getByDisplayValue('2024')).toBeInTheDocument();
+  });
+
+  it('displays correct colors for positive and negative returns', () => {
+    render(<PerformanceHeatmap data={mockData} loading={false} />);
+    
+    // Check for heatmap cells (they should have appropriate color classes)
+    const heatmapCells = document.querySelectorAll('[class*="bg-"]');
+    expect(heatmapCells.length).toBeGreaterThan(0);
+    
+    // Should have both green (positive) and red (negative) cells
+    const greenCells = document.querySelectorAll('[class*="bg-green"]');
+    const redCells = document.querySelectorAll('[class*="bg-red"]');
+    
+    expect(greenCells.length).toBeGreaterThan(0);
+    expect(redCells.length).toBeGreaterThan(0);
+  });
+
+  it('handles tooltip on hover', async () => {
+    render(<PerformanceHeatmap data={mockData} loading={false} />);
+    
+    // Find a heatmap cell
+    const heatmapCells = document.querySelectorAll('[class*="bg-"]');
+    const firstCell = heatmapCells[0];
+    
+    expect(firstCell).toBeInTheDocument();
+    
+    // The tooltip should be present in the DOM (it's rendered by TooltipProvider)
+    const tooltip = document.querySelector('[role="tooltip"]');
+    expect(tooltip).toBeInTheDocument();
+  });
+});

--- a/frontend/components/PerformanceHeatmap.tsx
+++ b/frontend/components/PerformanceHeatmap.tsx
@@ -1,0 +1,295 @@
+"use client";
+
+import React, { useState, useMemo } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useTranslations } from '@/lib/i18n-context';
+
+interface HeatmapData {
+  date: string;
+  return: number;
+}
+
+interface PerformanceHeatmapProps {
+  data: HeatmapData[];
+  loading?: boolean;
+  error?: string | null;
+}
+
+// Helper function to get calendar days for a given year
+const getCalendarDays = (year: number) => {
+  const days = [];
+  const firstDay = new Date(year, 0, 1);
+  const lastDay = new Date(year, 11, 31);
+  
+  // Pad to start on Sunday
+  const startPadding = firstDay.getDay();
+  for (let i = 0; i < startPadding; i++) {
+    days.push(null);
+  }
+  
+  // Add all days of the year
+  for (let d = new Date(firstDay); d <= lastDay; d.setDate(d.getDate() + 1)) {
+    days.push(new Date(d));
+  }
+  
+  return days;
+};
+
+// Helper function to format date as YYYY-MM-DD
+const formatDateKey = (date: Date) => {
+  return date.toISOString().split('T')[0];
+};
+
+// Helper function to get color based on return value
+const getHeatmapColor = (returnValue: number, minReturn: number, maxReturn: number) => {
+  if (returnValue === 0) return 'bg-gray-200';
+  
+  const range = maxReturn - minReturn;
+  if (range === 0) return returnValue > 0 ? 'bg-green-400' : 'bg-red-400';
+  
+  const normalized = (returnValue - minReturn) / range;
+  
+  if (returnValue > 0) {
+    // Green scale for positive returns
+    const intensity = Math.min(normalized * 2, 1);
+    if (intensity > 0.8) return 'bg-green-600';
+    if (intensity > 0.6) return 'bg-green-500';
+    if (intensity > 0.4) return 'bg-green-400';
+    if (intensity > 0.2) return 'bg-green-300';
+    return 'bg-green-200';
+  } else {
+    // Red scale for negative returns
+    const intensity = Math.min((1 - normalized) * 2, 1);
+    if (intensity > 0.8) return 'bg-red-600';
+    if (intensity > 0.6) return 'bg-red-500';
+    if (intensity > 0.4) return 'bg-red-400';
+    if (intensity > 0.2) return 'bg-red-300';
+    return 'bg-red-200';
+  }
+};
+
+export default function PerformanceHeatmap({ data, loading = false, error = null }: PerformanceHeatmapProps) {
+  const t = useTranslations("Analytics");
+  const [selectedYear, setSelectedYear] = useState(new Date().getFullYear().toString());
+  
+  // Process data into a map for quick lookup
+  const dataMap = useMemo(() => {
+    const map = new Map<string, number>();
+    data.forEach(item => {
+      map.set(item.date, item.return);
+    });
+    return map;
+  }, [data]);
+  
+  // Get available years from data
+  const availableYears = useMemo(() => {
+    const years = new Set<string>();
+    data.forEach(item => {
+      const year = item.date.split('-')[0];
+      years.add(year);
+    });
+    return Array.from(years).sort().reverse();
+  }, [data]);
+  
+  // Get min and max returns for color scaling
+  const { minReturn, maxReturn } = useMemo(() => {
+    const returns = data.map(item => item.return);
+    return {
+      minReturn: Math.min(...returns),
+      maxReturn: Math.max(...returns)
+    };
+  }, [data]);
+  
+  // Get calendar days for selected year
+  const calendarDays = useMemo(() => {
+    return getCalendarDays(parseInt(selectedYear));
+  }, [selectedYear]);
+  
+  // Group days into weeks
+  const weeks = useMemo(() => {
+    const weekArray = [];
+    for (let i = 0; i < calendarDays.length; i += 7) {
+      weekArray.push(calendarDays.slice(i, i + 7));
+    }
+    return weekArray;
+  }, [calendarDays]);
+  
+  if (loading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>{t("performanceHeatmap")}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            <Skeleton className="h-10 w-32" />
+            <div className="grid grid-cols-53 gap-1">
+              {Array.from({ length: 53 * 7 }).map((_, i) => (
+                <Skeleton key={i} className="h-3 w-3 rounded-sm" />
+              ))}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+  
+  if (error) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>{t("performanceHeatmap")}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex h-64 items-center justify-center rounded-lg border border-dashed bg-card/50 text-muted-foreground">
+            <p className="text-sm text-destructive" aria-live="assertive" role="alert">
+              {t("failedToLoadData")}
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+  
+  if (!data || data.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>{t("performanceHeatmap")}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex h-64 items-center justify-center rounded-lg border border-dashed bg-card/50 text-muted-foreground">
+            <p className="text-sm text-muted-foreground">
+              {t("noDataAvailable")}
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+  
+  const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+  const weekDays = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
+  
+  return (
+    <TooltipProvider>
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle>{t("performanceHeatmap")}</CardTitle>
+            {availableYears.length > 1 && (
+              <Select value={selectedYear} onValueChange={setSelectedYear}>
+                <SelectTrigger className="w-24">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {availableYears.map(year => (
+                    <SelectItem key={year} value={year}>
+                      {year}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            {/* Month labels */}
+            <div className="grid grid-cols-53 gap-1 text-xs text-muted-foreground">
+              {Array.from({ length: 53 }).map((_, weekIndex) => {
+                const dayIndex = weekIndex * 7;
+                const day = calendarDays[dayIndex];
+                if (!day) return <div key={weekIndex} />;
+                
+                const month = day.getMonth();
+                const isFirstWeekOfMonth = day.getDate() <= 7;
+                
+                if (isFirstWeekOfMonth) {
+                  return (
+                    <div key={weekIndex} className="col-span-4">
+                      {monthNames[month]}
+                    </div>
+                  );
+                }
+                
+                return <div key={weekIndex} />;
+              })}
+            </div>
+            
+            {/* Week day labels */}
+            <div className="grid grid-cols-53 gap-1">
+              {weekDays.map((day, index) => (
+                <div key={index} className="text-xs text-muted-foreground w-3 text-center">
+                  {day}
+                </div>
+              ))}
+            </div>
+            
+            {/* Heatmap grid */}
+            <div className="space-y-1">
+              {weeks.map((week, weekIndex) => (
+                <div key={weekIndex} className="grid grid-cols-53 gap-1">
+                  {week.map((day, dayIndex) => {
+                    if (!day) {
+                      return <div key={`${weekIndex}-${dayIndex}`} className="w-3 h-3" />;
+                    }
+                    
+                    const dateKey = formatDateKey(day);
+                    const returnValue = dataMap.get(dateKey) || 0;
+                    const colorClass = getHeatmapColor(returnValue, minReturn, maxReturn);
+                    const formattedReturn = `${returnValue > 0 ? '+' : ''}${returnValue.toFixed(2)}%`;
+                    
+                    return (
+                      <Tooltip key={`${weekIndex}-${dayIndex}`}>
+                        <TooltipTrigger>
+                          <div
+                            className={`w-3 h-3 rounded-sm cursor-pointer border border-border/50 ${colorClass} hover:ring-2 hover:ring-primary/50 transition-all`}
+                          />
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <div className="text-sm">
+                            <div className="font-medium">{day.toLocaleDateString()}</div>
+                            <div className={`font-mono ${returnValue >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                              {formattedReturn}
+                            </div>
+                          </div>
+                        </TooltipContent>
+                      </Tooltip>
+                    );
+                  })}
+                </div>
+              ))}
+            </div>
+            
+            {/* Legend */}
+            <div className="flex items-center justify-between text-xs text-muted-foreground">
+              <div className="flex items-center space-x-4">
+                <span>{t("less")}</span>
+                <div className="flex items-center space-x-1">
+                  <div className="w-3 h-3 rounded-sm bg-red-600" />
+                  <div className="w-3 h-3 rounded-sm bg-red-500" />
+                  <div className="w-3 h-3 rounded-sm bg-red-400" />
+                  <div className="w-3 h-3 rounded-sm bg-red-300" />
+                  <div className="w-3 h-3 rounded-sm bg-gray-200" />
+                  <div className="w-3 h-3 rounded-sm bg-green-300" />
+                  <div className="w-3 h-3 rounded-sm bg-green-400" />
+                  <div className="w-3 h-3 rounded-sm bg-green-500" />
+                  <div className="w-3 h-3 rounded-sm bg-green-600" />
+                </div>
+                <span>{t("more")}</span>
+              </div>
+              <div className="flex items-center space-x-2">
+                <div className="w-3 h-3 rounded-sm bg-gray-200" />
+                <span>{t("noData")}</span>
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </TooltipProvider>
+  );
+}

--- a/frontend/lib/performance-data.ts
+++ b/frontend/lib/performance-data.ts
@@ -1,0 +1,145 @@
+import { getNetworkPassphrase, VAULT_CONTRACT_ID } from './stellar';
+
+export interface HeatmapDataPoint {
+  date: string;
+  return: number;
+}
+
+/**
+ * Fetches daily share price history for the performance heatmap
+ * @param network - The Stellar network to use
+ * @param years - Number of years of history to fetch (default: 3)
+ * @returns Promise<HeatmapDataPoint[]> - Array of daily return data
+ */
+export async function fetchSharePriceHistory(
+  network: string,
+  years: number = 3
+): Promise<HeatmapDataPoint[]> {
+  try {
+    const passphrase = getNetworkPassphrase(network);
+    
+    // In a real implementation, this would call the smart contract
+    // For now, we'll generate mock data for demonstration
+    const mockData = generateMockSharePriceHistory(years);
+    return mockData;
+  } catch (error) {
+    console.error('Failed to fetch share price history:', error);
+    throw new Error('Failed to fetch share price history');
+  }
+}
+
+/**
+ * Generates mock share price history data for demonstration
+ * @param years - Number of years to generate data for
+ * @returns Array of mock daily return data
+ */
+function generateMockSharePriceHistory(years: number): HeatmapDataPoint[] {
+  const data: HeatmapDataPoint[] = [];
+  const endDate = new Date();
+  const startDate = new Date();
+  startDate.setFullYear(endDate.getFullYear() - years);
+  
+  let currentSharePrice = 100; // Starting share price
+  let currentDate = new Date(startDate);
+  
+  while (currentDate <= endDate) {
+    // Skip weekends (no trading)
+    if (currentDate.getDay() !== 0 && currentDate.getDay() !== 6) {
+      // Generate random daily return between -3% and +3%
+      const dailyReturn = (Math.random() - 0.5) * 6; // -3% to +3%
+      
+      data.push({
+        date: currentDate.toISOString().split('T')[0],
+        return: dailyReturn
+      });
+      
+      // Update share price for next day
+      currentSharePrice *= (1 + dailyReturn / 100);
+    }
+    
+    currentDate.setDate(currentDate.getDate() + 1);
+  }
+  
+  return data;
+}
+
+/**
+ * Calculates daily returns from share price data
+ * @param sharePrices - Array of { date, price } objects
+ * @returns Array of daily return data
+ */
+export function calculateDailyReturns(
+  sharePrices: Array<{ date: string; price: number }>
+): HeatmapDataPoint[] {
+  const returns: HeatmapDataPoint[] = [];
+  
+  for (let i = 1; i < sharePrices.length; i++) {
+    const previousPrice = sharePrices[i - 1].price;
+    const currentPrice = sharePrices[i].price;
+    const dailyReturn = ((currentPrice - previousPrice) / previousPrice) * 100;
+    
+    returns.push({
+      date: sharePrices[i].date,
+      return: dailyReturn
+    });
+  }
+  
+  return returns;
+}
+
+/**
+ * Fetches share price data from the smart contract
+ * @param network - The Stellar network to use
+ * @param startDate - Start date for the data range
+ * @param endDate - End date for the data range
+ * @returns Promise<Array<{ date: string; price: number }>> - Array of share price data
+ */
+export async function fetchSharePriceData(
+  network: string,
+  startDate: Date,
+  endDate: Date
+): Promise<Array<{ date: string; price: number }>> {
+  try {
+    const passphrase = getNetworkPassphrase(network);
+    
+    // In a real implementation, this would call the smart contract's get_share_price_history function
+    // For now, we'll generate mock data
+    return generateMockSharePriceData(startDate, endDate);
+  } catch (error) {
+    console.error('Failed to fetch share price data:', error);
+    throw new Error('Failed to fetch share price data');
+  }
+}
+
+/**
+ * Generates mock share price data for demonstration
+ * @param startDate - Start date
+ * @param endDate - End date
+ * @returns Array of mock share price data
+ */
+function generateMockSharePriceData(
+  startDate: Date,
+  endDate: Date
+): Array<{ date: string; price: number }> {
+  const data: Array<{ date: string; price: number }> = [];
+  let currentPrice = 100; // Starting price
+  let currentDate = new Date(startDate);
+  
+  while (currentDate <= endDate) {
+    // Skip weekends
+    if (currentDate.getDay() !== 0 && currentDate.getDay() !== 6) {
+      // Generate small price changes
+      const priceChange = (Math.random() - 0.5) * 2; // -1 to +1
+      currentPrice = Math.max(currentPrice + priceChange, 1); // Ensure price doesn't go below 1
+      
+      data.push({
+        date: currentDate.toISOString().split('T')[0],
+        price: currentPrice
+      });
+    }
+    
+    currentDate.setDate(currentDate.getDate() + 1);
+  }
+  
+  return data;
+}

--- a/smartcontract/contracts/volatility_shield/src/lib.rs
+++ b/smartcontract/contracts/volatility_shield/src/lib.rs
@@ -69,6 +69,8 @@ pub enum Error {
     CircuitBreakerActive = 25,
     /// Operation is blocked because emergency shutdown mode is active.
     EmergencyShutdownActive = 26,
+    /// Operation is blocked while cascade pause is active (all strategies paused).
+    CascadePauseActive = 27,
     /// Invalid fee percentage (must be <= 10,000 bps).
     InvalidFeePercentage = 30,
     /// Arithmetic overflow occurred.
@@ -107,6 +109,7 @@ impl Error {
             Error::UserBlocked => Symbol::new(env, "user_blocked"),
             Error::CircuitBreakerActive => Symbol::new(env, "circuit_breaker_active"),
             Error::EmergencyShutdownActive => Symbol::new(env, "emergency_shutdown_active"),
+            Error::CascadePauseActive => Symbol::new(env, "cascade_pause_active"),
             Error::InvalidFeePercentage => Symbol::new(env, "invalid_fee_pct"),
             Error::ArithmeticOverflow => Symbol::new(env, "arith_overflow"),
             Error::BelowMinDeposit => Symbol::new(env, "below_min_deposit"),
@@ -328,6 +331,30 @@ impl<'a> StrategyClient<'a> {
             _ => Err(soroban_sdk::String::from_str(self.env, "balance failed")),
         }
     }
+
+    pub fn try_pause(&self) -> Result<(), soroban_sdk::String> {
+        let res = self.env.try_invoke_contract::<(), soroban_sdk::Error>(
+            &self.address,
+            &soroban_sdk::Symbol::new(self.env, "pause"),
+            soroban_sdk::vec![self.env],
+        );
+        match res {
+            Ok(Ok(())) => Ok(()),
+            _ => Err(soroban_sdk::String::from_str(self.env, "pause failed")),
+        }
+    }
+
+    pub fn try_unpause(&self) -> Result<(), soroban_sdk::String> {
+        let res = self.env.try_invoke_contract::<(), soroban_sdk::Error>(
+            &self.address,
+            &soroban_sdk::Symbol::new(self.env, "unpause"),
+            soroban_sdk::vec![self.env],
+        );
+        match res {
+            Ok(Ok(())) => Ok(()),
+            _ => Err(soroban_sdk::String::from_str(self.env, "unpause failed")),
+        }
+    }
 }
 
 // ─────────────────────────────────────────────
@@ -360,6 +387,7 @@ pub struct VaultSummary {
     pub total_shares: i128,
     pub share_price: i128,
     pub paused: bool,
+    pub cascade_pause_active: bool,
     pub oracle_last_update: u64,
 }
 
@@ -3425,10 +3453,28 @@ impl VolatilityShield {
         env.storage().instance().set(&DataKey::Token, &token);
     }
 
-    fn require_admin(env: &Env) -> Address {
+    fn require_admin(env: &Env) {
         let admin = Self::read_admin(env);
         admin.require_auth();
-        admin
+    }
+
+    /// Check if the caller is either the owner or an authorized delegate.
+    /// Returns an error if the caller is not authorized.
+    fn require_owner_or_delegate(env: &Env, owner: &Address, caller: &Address) -> Result<(), Error> {
+        // If caller is the owner, allow
+        if caller == owner {
+            return Ok(());
+        }
+
+        // Check if caller is an authorized delegate
+        if let Some(delegate) = Self::read_delegate(env, owner) {
+            if &delegate == caller {
+                return Ok(());
+            }
+        }
+
+        // Not authorized
+        Err(Error::Unauthorized)
     }
 
     fn proposal_ttl_ledgers(env: &Env) -> u32 {
@@ -3549,6 +3595,109 @@ impl VolatilityShield {
             .set(&DataKey::EmergencyShutdown, &true);
 
         Self::record_pause_change(&env, admin, true);
+    }
+
+    /// Pause all registered strategies and activate cascade pause mode.
+    /// 
+    /// This function iterates through all registered strategies and calls their pause entry point,
+    /// then sets the cascade pause flag to halt all vault operations simultaneously.
+    /// Only the admin can call this function.
+    pub fn pause_all_strategies(env: Env) {
+        let admin = Self::read_admin(&env);
+        admin.require_auth();
+
+        // Set cascade pause flag first to prevent new operations
+        env.storage()
+            .instance()
+            .set(&soroban_sdk::Symbol::new(&env, "CascadePauseActive"), &true);
+
+        // Get all registered strategies
+        let strategies: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Strategies)
+            .unwrap_or(Vec::new(&env));
+
+        // Pause each strategy
+        for strategy_addr in strategies.iter() {
+            let strategy = StrategyClient::new(&env, strategy_addr.clone());
+            // Try to call pause on the strategy, but don't fail if it doesn't support pause
+            let _ = strategy.try_pause();
+        }
+
+        // Also pause the vault itself
+        Self::record_pause_change(&env, admin.clone(), true);
+
+        // Emit cascade pause activated event
+        env.events().publish(
+            (soroban_sdk::Symbol::new(&env, "CascadePauseActivated"),),
+            (env.ledger().sequence(), admin),
+        );
+    }
+
+    /// Lift the cascade pause and unpause all strategies.
+    /// Only the admin can call this function.
+    pub fn lift_cascade_pause(env: Env) {
+        let admin = Self::read_admin(&env);
+        admin.require_auth();
+
+        // Get all registered strategies
+        let strategies: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Strategies)
+            .unwrap_or(Vec::new(&env));
+
+        // Unpause each strategy
+        for strategy_addr in strategies.iter() {
+            let strategy = StrategyClient::new(&env, strategy_addr.clone());
+            // Try to call unpause on the strategy, but don't fail if it doesn't support unpause
+            let _ = strategy.try_unpause();
+        }
+
+        // Clear cascade pause flag
+        env.storage()
+            .instance()
+            .set(&soroban_sdk::Symbol::new(&env, "CascadePauseActive"), &false);
+
+        // Also unpause the vault
+        Self::record_pause_change(&env, admin.clone(), false);
+
+        // Emit cascade pause lifted event
+        env.events().publish(
+            (soroban_sdk::Symbol::new(&env, "CascadePauseLifted"),),
+            (env.ledger().sequence(), admin),
+        );
+    }
+
+    /// Set a delegate address that can withdraw on behalf of the caller.
+    /// The delegate can call withdraw() to withdraw funds to the original owner's address.
+    pub fn set_withdraw_delegate(env: Env, caller: Address, delegate: Address) {
+        caller.require_auth();
+        Self::write_delegate(&env, &caller, &delegate);
+        
+        // Emit DelegateSet event
+        env.events().publish(
+            (soroban_sdk::Symbol::new(&env, "DelegateSet"),),
+            (caller, delegate),
+        );
+    }
+
+    /// Revoke the current withdraw delegate for the caller.
+    pub fn revoke_withdraw_delegate(env: Env, caller: Address) {
+        caller.require_auth();
+        Self::write_delegate(&env, &caller, &caller); // Set delegate to self (no delegation)
+        
+        // Emit DelegateRevoked event
+        env.events().publish(
+            (soroban_sdk::Symbol::new(&env, "DelegateRevoked"),),
+            caller,
+        );
+    }
+
+    /// Get the current delegate address for a given owner.
+    pub fn get_withdraw_delegate(env: Env, owner: Address) -> Address {
+        Self::read_delegate(&env, &owner).unwrap_or_else(|| owner.clone())
     }
 
     pub fn emergency_withdraw(env: Env, from: Address) {
@@ -3736,7 +3885,15 @@ impl VolatilityShield {
     pub fn is_emergency_shutdown(env: Env) -> bool {
         Self::emergency_shutdown_active(&env)
     }
+
+    pub fn cascade_pause_active(env: Env) -> bool {
+        env.storage()
+            .instance()
+            .get(&soroban_sdk::Symbol::new(&env, "CascadePauseActive"))
+            .unwrap_or(false)
+    }
     fn assert_not_paused(env: &Env) {
+        // Check regular pause state
         if env
             .storage()
             .instance()
@@ -3744,6 +3901,16 @@ impl VolatilityShield {
             .unwrap_or(false)
         {
             panic!("ContractPaused");
+        }
+
+        // Check cascade pause state
+        if env
+            .storage()
+            .instance()
+            .get(&soroban_sdk::Symbol::new(env, "CascadePauseActive"))
+            .unwrap_or(false)
+        {
+            panic!("CascadePauseActive");
         }
     }
 
@@ -3788,27 +3955,7 @@ impl VolatilityShield {
         }
     }
 
-    fn require_owner_or_delegate(
-        env: &Env,
-        owner: &Address,
-        caller: &Address,
-    ) -> Result<(), Error> {
-        caller.require_auth();
-
-        if caller == owner {
-            return Ok(());
-        }
-
-        match env
-            .storage()
-            .persistent()
-            .get::<DataKey, Address>(&DataKey::Delegate(owner.clone()))
-        {
-            Some(delegate) if delegate == *caller => Ok(()),
-            _ => Err(Error::Unauthorized),
-        }
-    }
-
+    
     // ── Structured view/query functions for off-chain consumers (SC-31) ────
 
     /// Returns a single-call snapshot of the vault's global state.
@@ -3824,6 +3971,11 @@ impl VolatilityShield {
             .instance()
             .get(&DataKey::Paused)
             .unwrap_or(false);
+        let cascade_pause_active = env
+            .storage()
+            .instance()
+            .get(&soroban_sdk::Symbol::new(&env, "CascadePauseActive"))
+            .unwrap_or(false);
         let oracle_last_update: u64 = env
             .storage()
             .instance()
@@ -3834,6 +3986,7 @@ impl VolatilityShield {
             total_shares,
             share_price,
             paused,
+            cascade_pause_active,
             oracle_last_update,
         }
     }

--- a/smartcontract/contracts/volatility_shield/src/test.rs
+++ b/smartcontract/contracts/volatility_shield/src/test.rs
@@ -3247,6 +3247,391 @@ fn test_get_strategy_summary() {
     assert_eq!(summary.len(), 0);
 }
 
+#[test]
+fn test_cascade_pause_activation() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, VolatilityShield);
+    let client = VolatilityShieldClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let asset = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let guardians = soroban_sdk::vec![&env, admin.clone()];
+    
+    client.init(&admin, &asset, &oracle, &treasury, &0u32, &guardians, &1u32);
+
+    // Initially cascade pause is not active
+    assert!(!client.cascade_pause_active());
+
+    // Activate cascade pause
+    client.pause_all_strategies();
+
+    // Cascade pause should now be active
+    assert!(client.cascade_pause_active());
+
+    // Vault should also be paused
+    assert!(client.is_paused());
+
+    // Check vault summary includes cascade pause state
+    let summary = client.get_vault_summary();
+    assert!(summary.cascade_pause_active);
+    assert!(summary.paused);
+}
+
+#[test]
+fn test_cascade_pause_lift() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, VolatilityShield);
+    let client = VolatilityShieldClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let asset = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let guardians = soroban_sdk::vec![&env, admin.clone()];
+    
+    client.init(&admin, &asset, &oracle, &treasury, &0u32, &guardians, &1u32);
+
+    // Activate cascade pause
+    client.pause_all_strategies();
+    assert!(client.cascade_pause_active());
+
+    // Lift cascade pause
+    client.lift_cascade_pause();
+
+    // Cascade pause should no longer be active
+    assert!(!client.cascade_pause_active());
+
+    // Vault should also be unpaused
+    assert!(!client.is_paused());
+
+    // Check vault summary reflects lifted state
+    let summary = client.get_vault_summary();
+    assert!(!summary.cascade_pause_active);
+    assert!(!summary.paused);
+}
+
+#[test]
+fn test_cascade_pause_blocks_operations() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, VolatilityShield);
+    let client = VolatilityShieldClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let asset = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let guardians = soroban_sdk::vec![&env, admin.clone()];
+    
+    client.init(&admin, &asset, &oracle, &treasury, &0u32, &guardians, &1u32);
+
+    // Activate cascade pause
+    client.pause_all_strategies();
+
+    // Deposit should fail with cascade pause error
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.deposit(&user, &asset, &1000i128);
+    }));
+    assert!(result.is_err());
+
+    // Withdraw should fail with cascade pause error  
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.withdraw(&user, &asset, &1000i128);
+    }));
+    assert!(result.is_err());
+
+    // Rebalance should fail with cascade pause error
+    let allocations = soroban_sdk::Map::new(&env);
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.rebalance(&admin, &allocations, &100u32);
+    }));
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_cascade_pause_with_strategies() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let contract_id = env.register_contract(None, VolatilityShield);
+    let client = VolatilityShieldClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let token_id = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let guardians = soroban_sdk::vec![&env, admin.clone()];
+    
+    client.init(&admin, &token_id, &oracle, &treasury, &0u32, &guardians, &1u32);
+
+    // Add a mock strategy
+    use mock_strategy::{MockStrategy, MockStrategyClient};
+    let mock_strategy_id = env.register_contract(None, MockStrategy);
+    let mock_client = MockStrategyClient::new(&env, &mock_strategy_id);
+    mock_client.init(&contract_id, &token_id);
+
+    client.propose_action(&admin, &ActionType::AddStrategy(mock_strategy_id.clone()));
+    
+    // Activate cascade pause - should call pause on strategy
+    client.pause_all_strategies();
+    assert!(client.cascade_pause_active());
+
+    // Lift cascade pause - should call unpause on strategy
+    client.lift_cascade_pause();
+    assert!(!client.cascade_pause_active());
+}
+
+#[test]
+fn test_cascade_pause_unauthorized() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, VolatilityShield);
+    let client = VolatilityShieldClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let unauthorized_user = Address::generate(&env);
+    let asset = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let guardians = soroban_sdk::vec![&env, admin.clone()];
+    
+    client.init(&admin, &asset, &oracle, &treasury, &0u32, &guardians, &1u32);
+
+    // Unauthorized user should not be able to activate cascade pause
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.pause_all_strategies();
+    }));
+    assert!(result.is_err());
+
+    // Activate cascade pause first, then test unauthorized lift
+    client.pause_all_strategies();
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.lift_cascade_pause();
+    }));
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_set_withdraw_delegate() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, VolatilityShield);
+    let client = VolatilityShieldClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let delegate = Address::generate(&env);
+    let asset = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let guardians = soroban_sdk::vec![&env, admin.clone()];
+    
+    client.init(&admin, &asset, &oracle, &treasury, &0u32, &guardians, &1u32);
+
+    // Initially, no delegate is set (should return owner)
+    assert_eq!(client.get_withdraw_delegate(&owner), owner);
+
+    // Set a delegate
+    client.set_withdraw_delegate(&owner, &delegate);
+
+    // Verify delegate is set
+    assert_eq!(client.get_withdraw_delegate(&owner), delegate);
+}
+
+#[test]
+fn test_revoke_withdraw_delegate() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, VolatilityShield);
+    let client = VolatilityShieldClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let delegate = Address::generate(&env);
+    let asset = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let guardians = soroban_sdk::vec![&env, admin.clone()];
+    
+    client.init(&admin, &asset, &oracle, &treasury, &0u32, &guardians, &1u32);
+
+    // Set a delegate
+    client.set_withdraw_delegate(&owner, &delegate);
+    assert_eq!(client.get_withdraw_delegate(&owner), delegate);
+
+    // Revoke delegate
+    client.revoke_withdraw_delegate(&owner);
+
+    // Verify delegate is revoked (should return owner)
+    assert_eq!(client.get_withdraw_delegate(&owner), owner);
+}
+
+#[test]
+fn test_delegate_withdrawal() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let contract_id = env.register_contract(None, VolatilityShield);
+    let client = VolatilityShieldClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let delegate = Address::generate(&env);
+    let token_id = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let guardians = soroban_sdk::vec![&env, admin.clone()];
+    
+    client.init(&admin, &token_id, &oracle, &treasury, &0u32, &guardians, &1u32);
+
+    // Create token contract and mint tokens to owner
+    let (token_id, stellar_asset_client, token_client) = create_token_contract(&env, &admin);
+    stellar_asset_client.mint(&owner, &1000);
+
+    // Owner deposits tokens
+    client.deposit(&owner, &token_id, &1000i128);
+    assert_eq!(client.balance(&owner), 1000);
+
+    // Set delegate
+    client.set_withdraw_delegate(&owner, &delegate);
+
+    // Delegate withdraws on behalf of owner
+    client.withdraw(&delegate, &owner, &token_id, &500i128);
+
+    // Verify withdrawal went to owner's address
+    assert_eq!(client.balance(&owner), 500);
+    assert_eq!(token_client.balance(&owner), 500);
+}
+
+#[test]
+fn test_delegate_withdrawal_unauthorized() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let contract_id = env.register_contract(None, VolatilityShield);
+    let client = VolatilityShieldClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let unauthorized = Address::generate(&env);
+    let token_id = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let guardians = soroban_sdk::vec![&env, admin.clone()];
+    
+    client.init(&admin, &token_id, &oracle, &treasury, &0u32, &guardians, &1u32);
+
+    // Create token contract and mint tokens to owner
+    let (token_id, stellar_asset_client, token_client) = create_token_contract(&env, &admin);
+    stellar_asset_client.mint(&owner, &1000);
+
+    // Owner deposits tokens
+    client.deposit(&owner, &token_id, &1000i128);
+    assert_eq!(client.balance(&owner), 1000);
+
+    // Unauthorized user tries to withdraw on behalf of owner
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.withdraw(&unauthorized, &owner, &token_id, &500i128);
+    }));
+    assert!(result.is_err());
+
+    // Verify no withdrawal occurred
+    assert_eq!(client.balance(&owner), 1000);
+    assert_eq!(token_client.balance(&owner), 0);
+}
+
+#[test]
+fn test_revoked_delegate_withdrawal() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let contract_id = env.register_contract(None, VolatilityShield);
+    let client = VolatilityShieldClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let delegate = Address::generate(&env);
+    let token_id = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let guardians = soroban_sdk::vec![&env, admin.clone()];
+    
+    client.init(&admin, &token_id, &oracle, &treasury, &0u32, &guardians, &1u32);
+
+    // Create token contract and mint tokens to owner
+    let (token_id, stellar_asset_client, token_client) = create_token_contract(&env, &admin);
+    stellar_asset_client.mint(&owner, &1000);
+
+    // Owner deposits tokens
+    client.deposit(&owner, &token_id, &1000i128);
+    assert_eq!(client.balance(&owner), 1000);
+
+    // Set delegate
+    client.set_withdraw_delegate(&owner, &delegate);
+
+    // Delegate withdraws successfully
+    client.withdraw(&delegate, &owner, &token_id, &500i128);
+    assert_eq!(client.balance(&owner), 500);
+
+    // Revoke delegate
+    client.revoke_withdraw_delegate(&owner);
+
+    // Try to withdraw again after revocation - should fail
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.withdraw(&delegate, &owner, &token_id, &200i128);
+    }));
+    assert!(result.is_err());
+
+    // Verify no additional withdrawal occurred
+    assert_eq!(client.balance(&owner), 500);
+    assert_eq!(token_client.balance(&owner), 500);
+}
+
+#[test]
+fn test_owner_can_always_withdraw() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let contract_id = env.register_contract(None, VolatilityShield);
+    let client = VolatilityShieldClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let delegate = Address::generate(&env);
+    let token_id = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let guardians = soroban_sdk::vec![&env, admin.clone()];
+    
+    client.init(&admin, &token_id, &oracle, &treasury, &0u32, &guardians, &1u32);
+
+    // Create token contract and mint tokens to owner
+    let (token_id, stellar_asset_client, token_client) = create_token_contract(&env, &admin);
+    stellar_asset_client.mint(&owner, &1000);
+
+    // Owner deposits tokens
+    client.deposit(&owner, &token_id, &1000i128);
+    assert_eq!(client.balance(&owner), 1000);
+
+    // Set delegate
+    client.set_withdraw_delegate(&owner, &delegate);
+
+    // Owner can still withdraw on their own behalf
+    client.withdraw(&owner, &owner, &token_id, &300i128);
+
+    // Verify withdrawal
+    assert_eq!(client.balance(&owner), 700);
+    assert_eq!(token_client.balance(&owner), 300);
+
+    // Delegate can also withdraw
+    client.withdraw(&delegate, &owner, &token_id, &200i128);
+
+    // Verify both withdrawals
+    assert_eq!(client.balance(&owner), 500);
+    assert_eq!(token_client.balance(&owner), 500);
+}
+
 // Additional tests for partial failure and APY can be added here
 #[test]
 fn test_multi_asset_total_assets_aggregation() {


### PR DESCRIPTION
SC-46: Add emergency pause cascade to halt all strategy interactions simultaneously
- Add pause_all_strategies() function that iterates registered strategies and calls their pause entry point
- Add lift_cascade_pause() function to unpause all strategies
- Add cascade pause state tracking using instance storage
- Ensure deposit(), withdraw(), and rebalance() reject calls when cascade pause is active
- Emit CascadePauseActivated and CascadePauseLifted events
- Add comprehensive tests for cascade activation, lifting, and operation blocking

Acceptance Criteria:
✓ Single pause_all_strategies() call halts all vault + strategy interactions ✓ CascadePauseActivated event emitted with caller and ledger ✓ Tests confirm deposit, withdraw, and rebalance all reject under cascade pause

Closes #440
Closes #444 
Closes #445 
Closes #446