### PR TITLE
feat(frontend): wallet reconnect retry + vault health banner

### DIFF
--- a/frontend/components/VaultHealthBanner.spec.tsx
+++ b/frontend/components/VaultHealthBanner.spec.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { VaultHealthBanner } from "./VaultHealthBanner";
+
+describe("VaultHealthBanner", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("does not render when vault is healthy", () => {
+    render(
+      <VaultHealthBanner
+        unhealthyStrategiesCount={0}
+        vaultPaused={false}
+        cascadeHalt={false}
+      />
+    );
+    expect(screen.queryByTestId("vault-health-banner")).not.toBeInTheDocument();
+  });
+
+  it("renders warning when unhealthy strategy exists", () => {
+    render(
+      <VaultHealthBanner
+        unhealthyStrategiesCount={1}
+        vaultPaused={false}
+        cascadeHalt={false}
+      />
+    );
+    expect(screen.getByText(/Warning:/)).toBeInTheDocument();
+  });
+
+  it("renders critical when vault is paused", () => {
+    render(
+      <VaultHealthBanner
+        unhealthyStrategiesCount={1}
+        vaultPaused={true}
+        cascadeHalt={false}
+      />
+    );
+    expect(screen.getByText(/Critical:/)).toBeInTheDocument();
+  });
+
+  it("dismiss button hides banner", () => {
+    render(
+      <VaultHealthBanner
+        unhealthyStrategiesCount={1}
+        vaultPaused={false}
+        cascadeHalt={false}
+      />
+    );
+    fireEvent.click(screen.getByLabelText("Dismiss vault health banner"));
+    expect(screen.queryByTestId("vault-health-banner")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/components/VaultHealthBanner.tsx
+++ b/frontend/components/VaultHealthBanner.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import Link from "next/link";
+import { AlertTriangle, ShieldAlert, X } from "lucide-react";
+import { useMemo, useState } from "react";
+
+type Severity = "warning" | "critical";
+
+interface VaultHealthBannerProps {
+  unhealthyStrategiesCount: number;
+  vaultPaused: boolean;
+  cascadeHalt: boolean;
+  detailsHref?: string;
+}
+
+function getLoadId(): string {
+  if (typeof window === "undefined") return "server";
+  return String(window.performance.timeOrigin);
+}
+
+export function VaultHealthBanner({
+  unhealthyStrategiesCount,
+  vaultPaused,
+  cascadeHalt,
+  detailsHref = "/governance",
+}: VaultHealthBannerProps) {
+  const health = useMemo(() => {
+    if (vaultPaused || cascadeHalt) {
+      return {
+        severity: "critical" as Severity,
+        message: "Critical: Vault operations are paused or emergency halt is active.",
+      };
+    }
+    if (unhealthyStrategiesCount > 0) {
+      return {
+        severity: "warning" as Severity,
+        message: `Warning: ${unhealthyStrategiesCount} strategy is unhealthy.`,
+      };
+    }
+    return null;
+  }, [cascadeHalt, unhealthyStrategiesCount, vaultPaused]);
+
+  const [dismissed, setDismissed] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return (
+      sessionStorage.getItem("vault-health-banner-dismissed-load-id") === getLoadId()
+    );
+  });
+
+  if (!health || dismissed) return null;
+
+  const isCritical = health.severity === "critical";
+  return (
+    <div
+      data-testid="vault-health-banner"
+      className={`mb-4 rounded-lg border px-4 py-3 text-sm ${
+        isCritical
+          ? "border-red-300 bg-red-50 text-red-900"
+          : "border-amber-300 bg-amber-50 text-amber-900"
+      }`}
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex items-start gap-2">
+          {isCritical ? (
+            <ShieldAlert className="mt-0.5 h-4 w-4" />
+          ) : (
+            <AlertTriangle className="mt-0.5 h-4 w-4" />
+          )}
+          <div>
+            <p>{health.message}</p>
+            <Link href={detailsHref} className="mt-1 inline-block underline">
+              View governance and analytics details
+            </Link>
+          </div>
+        </div>
+        <button
+          type="button"
+          aria-label="Dismiss vault health banner"
+          onClick={() => {
+            sessionStorage.setItem(
+              "vault-health-banner-dismissed-load-id",
+              getLoadId()
+            );
+            setDismissed(true);
+          }}
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/vault-overview-card.tsx
+++ b/frontend/components/vault-overview-card.tsx
@@ -12,6 +12,7 @@ import { StaleBadge } from "@/components/StaleBadge";
 import { VaultOverviewSkeleton } from "@/components/ui/skeleton";
 import { useRealtimeVault } from "@/hooks/use-realtime-vault";
 import { ConnectionStatusIndicator } from "@/components/ConnectionStatusIndicator";
+import { VaultHealthBanner } from "@/components/VaultHealthBanner";
 import type { VaultMetrics } from "@/lib/stellar";
 
 export function VaultOverviewCard() {
@@ -45,9 +46,25 @@ export function VaultOverviewCard() {
   const totalShares = parseFloat(metrics?.totalShares || "0") / 1e7;
   const sharePrice = parseFloat(metrics?.sharePrice || "1.0000000");
   const userBalance = optimisticBalance;
+  const unhealthyStrategiesCount = Number(
+    (metrics as VaultMetrics & { unhealthyStrategiesCount?: number })?.unhealthyStrategiesCount ?? 0
+  );
+  const vaultPaused = Boolean(
+    (metrics as VaultMetrics & { vaultPaused?: boolean; isPaused?: boolean })?.vaultPaused ??
+      (metrics as VaultMetrics & { isPaused?: boolean })?.isPaused
+  );
+  const cascadeHalt = Boolean(
+    (metrics as VaultMetrics & { cascadeHalt?: boolean; cascadeHaltActive?: boolean })?.cascadeHalt ??
+      (metrics as VaultMetrics & { cascadeHaltActive?: boolean })?.cascadeHaltActive
+  );
 
   return (
     <div className="rounded-lg border bg-card p-6 shadow-sm">
+      <VaultHealthBanner
+        unhealthyStrategiesCount={unhealthyStrategiesCount}
+        vaultPaused={vaultPaused}
+        cascadeHalt={cascadeHalt}
+      />
       <div className="flex items-center justify-between mb-6">
         <div className="flex items-center gap-3">
           <Shield className="w-6 h-6 text-primary" />

--- a/frontend/hooks/use-wallet.spec.ts
+++ b/frontend/hooks/use-wallet.spec.ts
@@ -1,0 +1,54 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useWallet } from "./use-wallet";
+
+const mockSignTransaction = vi.fn();
+const mockRequestAccess = vi.fn();
+
+vi.mock("@stellar/freighter-api", () => ({
+  isConnected: vi.fn().mockResolvedValue(true),
+  getPublicKey: vi.fn().mockResolvedValue("GTESTPUBLICKEY"),
+  signTransaction: (...args: unknown[]) => mockSignTransaction(...args),
+  getNetwork: vi.fn().mockResolvedValue("testnet"),
+  requestAccess: (...args: unknown[]) => mockRequestAccess(...args),
+}));
+
+describe("useWallet reconnect flow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequestAccess.mockResolvedValue("GTESTPUBLICKEY");
+  });
+
+  it("retries signTransaction after reconnect on auth failure", async () => {
+    mockSignTransaction
+      .mockRejectedValueOnce(new Error("not_allowed"))
+      .mockResolvedValueOnce("SIGNED_XDR");
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    const { result } = renderHook(() => useWallet());
+
+    let signed: { error: string | null; signedTxXdr: string | null } | undefined;
+    await act(async () => {
+      signed = await result.current.signTransaction("XDR", "PASS");
+    });
+
+    expect(window.confirm).toHaveBeenCalled();
+    expect(mockRequestAccess).toHaveBeenCalledTimes(1);
+    expect(mockSignTransaction).toHaveBeenCalledTimes(2);
+    expect(signed).toEqual({ error: null, signedTxXdr: "SIGNED_XDR" });
+  });
+
+  it("returns session expired when user stays disconnected", async () => {
+    mockSignTransaction.mockRejectedValue(new Error("user_rejected"));
+    vi.spyOn(window, "confirm").mockReturnValue(false);
+
+    const { result } = renderHook(() => useWallet());
+    let signed: { error: string | null; signedTxXdr: string | null } | undefined;
+    await act(async () => {
+      signed = await result.current.signTransaction("XDR", "PASS");
+    });
+
+    expect(mockRequestAccess).not.toHaveBeenCalled();
+    expect(signed).toEqual({ error: "Wallet session expired", signedTxXdr: null });
+  });
+});

--- a/frontend/hooks/use-wallet.ts
+++ b/frontend/hooks/use-wallet.ts
@@ -83,6 +83,9 @@ export function useWallet() {
   }, [checkConnection]);
 
   const signTx = useCallback(async (xdr: string, networkPassphrase: string) => {
+    const isRecoverableAuthError = (message: string) =>
+      message.includes("not_allowed") || message.includes("user_rejected");
+
     try {
       const result = await signTransaction(xdr, {
         networkPassphrase,
@@ -94,8 +97,38 @@ export function useWallet() {
       
       return { error: "Failed to sign transaction", signedTxXdr: null };
     } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to sign transaction";
+
+      if (isRecoverableAuthError(message) && typeof window !== "undefined") {
+        const shouldReconnect = window.confirm(
+          "Wallet session expired - click to reconnect"
+        );
+
+        if (!shouldReconnect) {
+          return { error: "Wallet session expired", signedTxXdr: null };
+        }
+
+        try {
+          await requestAccess();
+          const retryResult = await signTransaction(xdr, { networkPassphrase });
+          if (typeof retryResult === "string") {
+            return { error: null, signedTxXdr: retryResult };
+          }
+          return { error: "Failed to sign transaction after reconnect", signedTxXdr: null };
+        } catch (retryError) {
+          return {
+            error:
+              retryError instanceof Error
+                ? retryError.message
+                : "Failed to reconnect wallet",
+            signedTxXdr: null,
+          };
+        }
+      }
+
       return { 
-        error: error instanceof Error ? error.message : "Failed to sign transaction", 
+        error: message, 
         signedTxXdr: null 
       };
     }


### PR DESCRIPTION
Closes #455  
Closes #459  
Closes #449  
Closes #447

## Changes
- Added wallet reconnect prompt flow on Freighter auth errors (`not_allowed`, `user_rejected`) with automatic action retry after reconnect.
- Added a dismissible `VaultHealthBanner` component with warning/critical severity states and a governance link.
- Wired the health banner into the vault overview card on the dashboard.
- Added unit tests for reconnect retry and dismiss flow, plus banner severity and dismiss behavior.

## Testing
- Not run (per request).
