### PR TITLE
feat(frontend): add dark/light theme toggle with system preference detection

### DIFF
--- a/frontend/app/providers.tsx
+++ b/frontend/app/providers.tsx
@@ -23,7 +23,7 @@ interface ProvidersProps {
 
 export function Providers({ children, nonce }: ProvidersProps) {
   return (
-    <ThemeProvider attribute="class" defaultTheme="system" enableSystem nonce={nonce}>
+    <ThemeProvider attribute="class" defaultTheme="system" enableSystem storageKey="vault-theme" nonce={nonce}>
       <I18nProvider>
         <FreighterProvider>
           <NetworkProvider>

--- a/frontend/components/ThemeToggle.tsx
+++ b/frontend/components/ThemeToggle.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { Sun, Moon, Monitor } from "lucide-react";
+import { useTheme, type Theme } from "@/hooks/use-theme";
+import { cn } from "@/lib/utils";
+
+// Static lookup — zero allocation per render
+const ICON: Readonly<Record<Theme, React.ElementType>> = {
+  light: Sun,
+  dark: Moon,
+  system: Monitor,
+} as const;
+
+// aria-label describes the *action* (what clicking will do next)
+const ARIA_LABEL: Readonly<Record<Theme, string>> = {
+  system: "Switch to light mode",
+  light: "Switch to dark mode",
+  dark: "Switch to system theme",
+} as const;
+
+interface ThemeToggleProps {
+  className?: string;
+}
+
+export function ThemeToggle({ className }: ThemeToggleProps) {
+  const { theme, cycleTheme } = useTheme();
+  const Icon = ICON[theme];
+
+  return (
+    <button
+      type="button"
+      onClick={cycleTheme}
+      aria-label={ARIA_LABEL[theme]}
+      className={cn(
+        "flex items-center justify-center w-8 h-8 rounded-md transition-colors",
+        "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+        className
+      )}
+    >
+      <Icon className="w-4 h-4" aria-hidden="true" />
+    </button>
+  );
+}

--- a/frontend/components/sidebar.tsx
+++ b/frontend/components/sidebar.tsx
@@ -10,7 +10,7 @@ import { useNetwork, NetworkType } from "@/app/context/NetworkContext";
 import { useCurrency, Currency } from "@/app/context/CurrencyContext";
 import { usePrices } from "@/app/context/PriceContext";
 import { NotificationBell } from "./NotificationBell";
-
+import { ThemeToggle } from "./ThemeToggle";
 
 const navItems = [
   { href: "/", label: "Dashboard", icon: Home },
@@ -54,7 +54,8 @@ export function Sidebar() {
         {isOpen ? <X className="w-5 h-5" aria-hidden="true" /> : <Menu className="w-5 h-5" aria-hidden="true" />}
       </button>
 
-      <div className="fixed top-4 right-4 z-50 lg:hidden">
+      <div className="fixed top-4 right-4 z-50 lg:hidden flex items-center gap-2">
+        <ThemeToggle className="bg-sidebar border border-sidebar-border shadow-sm" />
         <NotificationBell className="bg-sidebar border border-sidebar-border shadow-sm" />
       </div>
 
@@ -89,7 +90,10 @@ export function Sidebar() {
               <Shield className="w-8 h-8 text-primary" />
               <span className="text-xl font-bold text-foreground">XHedge</span>
             </div>
-            <NotificationBell className="hidden lg:flex" />
+            <div className="hidden lg:flex items-center gap-1">
+              <ThemeToggle />
+              <NotificationBell />
+            </div>
           </div>
 
           <nav aria-label="Primary" className="flex-1 px-3 py-4 space-y-1">

--- a/frontend/hooks/__tests__/use-theme.test.ts
+++ b/frontend/hooks/__tests__/use-theme.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useTheme } from "../use-theme";
+
+// ---------------------------------------------------------------------------
+// Mock next-themes so tests are pure unit tests with no DOM theme side-effects
+// ---------------------------------------------------------------------------
+vi.mock("next-themes", () => ({
+  useTheme: vi.fn(),
+}));
+
+import { useTheme as useNextTheme } from "next-themes";
+
+const mockSetTheme = vi.fn();
+
+/** Build a minimal next-themes mock return value */
+function mockNextTheme(theme: string, resolvedTheme: string) {
+  vi.mocked(useNextTheme).mockReturnValue({
+    theme,
+    resolvedTheme,
+    setTheme: mockSetTheme,
+    themes: ["light", "dark", "system"],
+    systemTheme: resolvedTheme as "light" | "dark",
+    forcedTheme: undefined,
+  });
+}
+
+// ---------------------------------------------------------------------------
+
+describe("useTheme", () => {
+  beforeEach(() => {
+    mockSetTheme.mockReset();
+  });
+
+  // -------------------------------------------------------------------------
+  // 1. Default system detection
+  // -------------------------------------------------------------------------
+  it("returns 'system' as the default theme and exposes the resolved OS theme", () => {
+    mockNextTheme("system", "dark");
+
+    const { result } = renderHook(() => useTheme());
+
+    expect(result.current.theme).toBe("system");
+    // resolvedTheme reflects the actual OS-rendered value
+    expect(result.current.resolvedTheme).toBe("dark");
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. Manual toggle — full cycle: system → light → dark → system
+  // -------------------------------------------------------------------------
+  it("cycles system → light → dark → system on successive cycleTheme calls", () => {
+    // system → light
+    mockNextTheme("system", "dark");
+    const { result: r1 } = renderHook(() => useTheme());
+    act(() => { r1.current.cycleTheme(); });
+    expect(mockSetTheme).toHaveBeenLastCalledWith("light");
+
+    // light → dark
+    mockNextTheme("light", "light");
+    const { result: r2 } = renderHook(() => useTheme());
+    act(() => { r2.current.cycleTheme(); });
+    expect(mockSetTheme).toHaveBeenLastCalledWith("dark");
+
+    // dark → system
+    mockNextTheme("dark", "dark");
+    const { result: r3 } = renderHook(() => useTheme());
+    act(() => { r3.current.cycleTheme(); });
+    expect(mockSetTheme).toHaveBeenLastCalledWith("system");
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. Persistence across reload — setTheme writes to localStorage[vault-theme]
+  // -------------------------------------------------------------------------
+  it("persists the selected theme under the 'vault-theme' localStorage key", () => {
+    const store: Record<string, string> = {};
+    vi.stubGlobal("localStorage", {
+      getItem: (k: string) => store[k] ?? null,
+      setItem: (k: string, v: string) => { store[k] = v; },
+      removeItem: (k: string) => { delete store[k]; },
+      clear: () => { for (const k in store) delete store[k]; },
+    });
+
+    // Simulate what next-themes does when storageKey="vault-theme":
+    // calling setTheme writes to localStorage under that key.
+    vi.mocked(useNextTheme).mockReturnValue({
+      theme: "system",
+      resolvedTheme: "dark",
+      setTheme: (t: string) => {
+        store["vault-theme"] = t;
+        mockSetTheme(t);
+      },
+      themes: ["light", "dark", "system"],
+      systemTheme: "dark",
+      forcedTheme: undefined,
+    });
+
+    const { result } = renderHook(() => useTheme());
+
+    act(() => { result.current.setTheme("dark"); });
+    expect(store["vault-theme"]).toBe("dark");
+
+    // Simulating reload: read persisted key, next-themes would restore from it
+    act(() => { result.current.setTheme("light"); });
+    expect(store["vault-theme"]).toBe("light");
+
+    // Verify next-themes setTheme was called (it owns the persistence logic)
+    expect(mockSetTheme).toHaveBeenCalledTimes(2);
+    expect(mockSetTheme).toHaveBeenNthCalledWith(1, "dark");
+    expect(mockSetTheme).toHaveBeenNthCalledWith(2, "light");
+  });
+});

--- a/frontend/hooks/use-theme.ts
+++ b/frontend/hooks/use-theme.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { useTheme as useNextTheme } from "next-themes";
+
+export type Theme = "light" | "dark" | "system";
+
+// Deterministic O(1) cycle map — no runtime allocation per call
+const NEXT_THEME: Readonly<Record<Theme, Theme>> = {
+  system: "light",
+  light: "dark",
+  dark: "system",
+} as const;
+
+export interface UseThemeReturn {
+  /** The stored user preference: "light" | "dark" | "system" */
+  theme: Theme;
+  /** The actual rendered theme after resolving "system" — undefined during SSR */
+  resolvedTheme: "light" | "dark" | undefined;
+  /** Set theme directly */
+  setTheme: (theme: Theme) => void;
+  /** Rotate through system → light → dark → system */
+  cycleTheme: () => void;
+}
+
+export function useTheme(): UseThemeReturn {
+  const { theme, resolvedTheme, setTheme } = useNextTheme();
+
+  const current = (theme as Theme) ?? "system";
+
+  return {
+    theme: current,
+    resolvedTheme: resolvedTheme as "light" | "dark" | undefined,
+    setTheme: (t: Theme) => setTheme(t),
+    cycleTheme: () => setTheme(NEXT_THEME[current]),
+  };
+}


### PR DESCRIPTION

Closes #470 
- Add storageKey="vault-theme" to ThemeProvider for localStorage persistence
- Create hooks/use-theme.ts: typed wrapper over next-themes with O(1) cycle map (system→light→dark→system)
- Create components/ThemeToggle.tsx: keyboard-accessible sun/moon/monitor button with aria-label
- Add ThemeToggle to sidebar header (desktop) and mobile top bar
- Add 3 Vitest unit tests: default system detection, full cycle, localStorage persistence